### PR TITLE
Auto-reload config file on changes

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,8 +1,12 @@
+import os
+import tempfile
 import unittest
 
+import yaml
+from tornado.options import options
 from tornado.web import Application
 from webssh import handler
-from webssh.main import app_listen
+from webssh.main import app_listen, reload_config
 
 
 class TestMain(unittest.TestCase):
@@ -20,3 +24,109 @@ class TestMain(unittest.TestCase):
         server_settings = dict(ssl_options='enabled')
         app_listen(app, 80, '127.0.0.1', server_settings)
         self.assertTrue(handler.redirecting)
+
+
+class TestReloadConfig(unittest.TestCase):
+
+    def _make_config(self, data):
+        f = tempfile.NamedTemporaryFile(
+            mode='w', suffix='.yaml', delete=False)
+        yaml.dump(data, f)
+        f.close()
+        return f.name
+
+    def _make_host_keys_settings(self):
+        from paramiko import HostKeys
+        return {
+            'host_keys': HostKeys(),
+            'system_host_keys': HostKeys(),
+            'host_keys_filename': ''
+        }
+
+    def test_reload_updates_allowed_hosts(self):
+        config = self._make_config({
+            'hosts': [{'hostname': '10.0.0.1', 'name': 'server1'}]
+        })
+        live = {'allowed_hosts': [], 'policy': None}
+        hks = self._make_host_keys_settings()
+        try:
+            reload_config(config, live, hks)
+            self.assertEqual(len(live['allowed_hosts']), 1)
+            self.assertEqual(live['allowed_hosts'][0]['hostname'], '10.0.0.1')
+        finally:
+            os.unlink(config)
+
+    def test_reload_invalid_hosts_keeps_previous(self):
+        config = self._make_config({
+            'hosts': [{'not_hostname': 'bad'}]
+        })
+        live = {'allowed_hosts': [{'hostname': 'old'}]}
+        hks = self._make_host_keys_settings()
+        try:
+            reload_config(config, live, hks)
+            # Previous config preserved
+            self.assertEqual(live['allowed_hosts'][0]['hostname'], 'old')
+        finally:
+            os.unlink(config)
+
+    def test_reload_invalid_yaml_keeps_previous(self):
+        f = tempfile.NamedTemporaryFile(
+            mode='w', suffix='.yaml', delete=False)
+        f.write(': invalid: yaml: [')
+        f.close()
+        live = {'allowed_hosts': [{'hostname': 'old'}]}
+        hks = self._make_host_keys_settings()
+        try:
+            reload_config(f.name, live, hks)
+            self.assertEqual(live['allowed_hosts'][0]['hostname'], 'old')
+        finally:
+            os.unlink(f.name)
+
+    def test_reload_idle_timeout_valid(self):
+        config = self._make_config({'idle_timeout': 600})
+        live = {'allowed_hosts': []}
+        hks = self._make_host_keys_settings()
+        old = options.idletimeout
+        try:
+            reload_config(config, live, hks)
+            self.assertEqual(options.idletimeout, 600)
+        finally:
+            options.idletimeout = old
+            os.unlink(config)
+
+    def test_reload_idle_timeout_negative_keeps_previous(self):
+        config = self._make_config({'idle_timeout': -1})
+        live = {'allowed_hosts': []}
+        hks = self._make_host_keys_settings()
+        old = options.idletimeout
+        try:
+            reload_config(config, live, hks)
+            self.assertEqual(options.idletimeout, old)
+        finally:
+            os.unlink(config)
+
+    def test_reload_idle_timeout_invalid_keeps_previous(self):
+        config = self._make_config({'idle_timeout': 'not_a_number'})
+        live = {'allowed_hosts': []}
+        hks = self._make_host_keys_settings()
+        old = options.idletimeout
+        try:
+            reload_config(config, live, hks)
+            self.assertEqual(options.idletimeout, old)
+        finally:
+            os.unlink(config)
+
+    def test_reload_atomic_on_policy_failure(self):
+        """If policy validation fails, allowed_hosts should not update."""
+        config = self._make_config({
+            'hosts': [{'hostname': '10.0.0.2', 'name': 'new'}],
+            'policy': 'invalid_policy'
+        })
+        live = {'allowed_hosts': [{'hostname': 'old'}], 'policy': None}
+        hks = self._make_host_keys_settings()
+        try:
+            reload_config(config, live, hks)
+            # Neither should update
+            self.assertEqual(live['allowed_hosts'][0]['hostname'], 'old')
+        finally:
+            os.unlink(config)

--- a/webssh/handler.py
+++ b/webssh/handler.py
@@ -344,7 +344,7 @@ class IndexHandler(MixinHandler, tornado.web.RequestHandler):
                    user_key_dir='', user_header='X-Authentik-Username',
                    live_config=None):
         super(IndexHandler, self).initialize(loop)
-        self.live_config = live_config or {}
+        self.live_config = live_config if live_config is not None else {}
         self.policy = self.live_config.get('policy', policy)
         self.host_keys_settings = self.live_config.get(
             'host_keys_settings', host_keys_settings)

--- a/webssh/main.py
+++ b/webssh/main.py
@@ -81,38 +81,66 @@ DEFAULT_CONFIG_PATH = '/data/config.yaml'
 
 
 def reload_config(config_path, live_config, host_keys_settings):
-    """Reload allowed_hosts and policy from the config file."""
+    """Reload allowed_hosts, policy, and idle_timeout from the config file.
+
+    Validates all values before applying any changes so a partial failure
+    does not leave live_config in an inconsistent state.
+    """
     try:
         data = load_config_file(config_path)
     except Exception as exc:
         logging.error('Failed to reload config: {}'.format(exc))
         return
 
+    # Stage all values before applying
+    updates = {}
+
     try:
-        allowed_hosts = parse_allowed_hosts(data)
-        live_config['allowed_hosts'] = allowed_hosts
-        logging.info('Reloaded allowed_hosts ({} hosts)'.format(
-            len(allowed_hosts)))
+        updates['allowed_hosts'] = parse_allowed_hosts(data)
     except ValueError as exc:
-        logging.error('Invalid hosts in config: {}'.format(exc))
+        logging.error('Invalid hosts in config reload: {}'.format(exc))
+        return
 
     if 'policy' in data:
         try:
+            from webssh.policy import check_policy_setting
             policy_class = get_policy_class(data['policy'])
-            live_config['policy'] = policy_class()
-            logging.info('Reloaded policy: {}'.format(
-                policy_class.__name__))
+            check_policy_setting(policy_class, host_keys_settings)
+            updates['policy'] = policy_class()
         except ValueError as exc:
-            logging.error('Invalid policy in config: {}'.format(exc))
+            logging.error('Invalid policy in config reload: {}'.format(exc))
+            return
 
+    new_idle_timeout = None
     if 'idle_timeout' in data:
         try:
-            timeout = int(data['idle_timeout'])
-            if timeout >= 0:
-                options.idletimeout = timeout
-                logging.info('Reloaded idle_timeout: {}'.format(timeout))
+            new_idle_timeout = int(data['idle_timeout'])
         except (TypeError, ValueError):
-            logging.error('Invalid idle_timeout in config')
+            logging.error(
+                'Invalid idle_timeout in config reload: {!r}'.format(
+                    data['idle_timeout']))
+            return
+        if new_idle_timeout < 0:
+            logging.error(
+                'Invalid idle_timeout (must be >= 0): {}'.format(
+                    new_idle_timeout))
+            return
+
+    # All validation passed — apply atomically
+    for key, value in updates.items():
+        live_config[key] = value
+
+    if new_idle_timeout is not None:
+        options.idletimeout = new_idle_timeout
+
+    parts = []
+    if 'allowed_hosts' in updates:
+        parts.append('{} hosts'.format(len(updates['allowed_hosts'])))
+    if 'policy' in updates:
+        parts.append('policy={}'.format(data['policy']))
+    if new_idle_timeout is not None:
+        parts.append('idle_timeout={}'.format(new_idle_timeout))
+    logging.info('Config reloaded: {}'.format(', '.join(parts)))
 
 
 def start_config_watcher(config_path, live_config, host_keys_settings,


### PR DESCRIPTION
## Summary
- Watch the YAML config file for modifications (mtime check every 5s)
- Hot-reload `allowed_hosts`, `policy`, and `idle_timeout` without restarting
- Handlers read from a shared `live_config` dict on each request, so changes take effect immediately
- Errors in the reloaded config are logged but don't crash the server — the previous config stays active

## What reloads
- `hosts` (allowed hosts list, including host keys)
- `policy` (warning/reject)
- `idle_timeout`

## What doesn't reload (requires restart)
- SSL/TLS settings
- Port/address bindings
- `userkeydir` / `userheader`
- `trusted_proxies`

## Test plan
- [x] All 144 tests pass
- [ ] Edit config.yaml while running and verify hosts list updates
- [ ] Introduce invalid YAML and verify server logs error but keeps running

🤖 Generated with [Claude Code](https://claude.com/claude-code)