### PR TITLE
Fix terminal container background and left padding

### DIFF
--- a/webssh/static/css/fullscreen.min.css
+++ b/webssh/static/css/fullscreen.min.css
@@ -1,2 +1,2 @@
-.xterm.fullscreen{position:fixed;top:0;bottom:0;left:0;right:0;width:auto;height:auto;z-index:255;background:black;padding-left:4px}
+.xterm.fullscreen{position:fixed;top:0;bottom:0;left:4px;right:0;width:auto;height:auto;z-index:255;background:black}
 /*# sourceMappingURL=fullscreen.min.css.map */

--- a/webssh/static/css/main.css
+++ b/webssh/static/css/main.css
@@ -724,6 +724,7 @@ textarea.pubkey-display:focus {
   bottom: 0;
   visibility: hidden;
   pointer-events: none;
+  background: black;
 }
 
 .terminal-pane.active {
@@ -761,13 +762,11 @@ body.has-tabs .terminal-pane .xterm.fullscreen {
   position: absolute;
   top: 0;
   bottom: 0;
-  left: 0;
+  left: 4px;
   right: 0;
   width: auto;
   height: auto;
   z-index: auto;
-  background: black;
-  padding-left: 4px;
 }
 
 /* --- Responsive --- */


### PR DESCRIPTION
## Summary
- Fix white bar on right side of terminal by setting `background: black` on `.terminal-pane`
- Fix left padding not working by using `left: 4px` offset instead of `padding-left` (absolutely-positioned canvas elements inside xterm ignore parent padding)

Follow-up to #23 — the padding/background fix didn't work with the WebGL renderer's canvas positioning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)