### PR TITLE
Fix terminal background and left padding

### DIFF
--- a/webssh/static/css/fullscreen.min.css
+++ b/webssh/static/css/fullscreen.min.css
@@ -1,2 +1,2 @@
-.xterm.fullscreen{position:fixed;top:0;bottom:0;left:4px;right:0;width:auto;height:auto;z-index:255;background:black}
+.xterm.fullscreen{position:fixed;top:0;bottom:0;left:0;right:0;width:auto;height:auto;z-index:255;background:black}
 /*# sourceMappingURL=fullscreen.min.css.map */

--- a/webssh/static/css/main.css
+++ b/webssh/static/css/main.css
@@ -714,6 +714,7 @@ textarea.pubkey-display:focus {
   position: relative;
   flex: 1;
   z-index: 1;
+  background: black;
 }
 
 .terminal-pane {
@@ -762,11 +763,22 @@ body.has-tabs .terminal-pane .xterm.fullscreen {
   position: absolute;
   top: 0;
   bottom: 0;
-  left: 4px;
+  left: 0;
   right: 0;
   width: auto;
   height: auto;
   z-index: auto;
+}
+
+/* Pad the terminal screen so text isn't flush against the left edge,
+   and ensure the viewport background covers any gap on the right where
+   the character grid doesn't perfectly tile. */
+.xterm .xterm-screen {
+  padding-left: 4px;
+}
+
+.xterm .xterm-viewport {
+  background-color: black !important;
 }
 
 /* --- Responsive --- */


### PR DESCRIPTION
## Summary
- Apply padding and background at the xterm-screen/viewport level instead of outer containers
- Previous attempts using `left` offset or `padding-left` on the fullscreen container didn't work because xterm's canvas is absolutely positioned inside `.xterm-screen`

🤖 Generated with [Claude Code](https://claude.com/claude-code)