### PR TITLE
Force xterm viewport background to black

### DIFF
--- a/webssh/static/js/main.js
+++ b/webssh/static/js/main.js
@@ -833,6 +833,13 @@ jQuery(function($){
           console.warn('WebGL renderer not available, using DOM fallback:', e);
         }
 
+        // Force viewport background to black — xterm 6.0 may set it via
+        // inline style that overrides CSS rules.
+        var viewport = tab.containerEl.querySelector('.xterm-viewport');
+        if (viewport) {
+          viewport.style.backgroundColor = 'black';
+        }
+
         tab.state = CONNECTED;
         tabManager.updateTabLabel(tab.id, tab.title || default_title);
         tabManager.updateTabStatus(tab.id);


### PR DESCRIPTION
Fix white bar on right side of terminal by setting viewport background-color via JS after terminal opens, since xterm 6.0 overrides CSS with inline styles.