### PR TITLE
Accept tmux's empty-selector OSC 52 clipboard writes

### DIFF
--- a/webssh/static/js/main.js
+++ b/webssh/static/js/main.js
@@ -721,7 +721,27 @@ jQuery(function($){
       term.fitAddon = fitAddon;
       term.loadAddon(fitAddon);
       term.loadAddon(new window.WebLinksAddon.WebLinksAddon());
-      term.loadAddon(new window.ClipboardAddon.ClipboardAddon());
+      // Custom clipboard provider: tmux emits OSC 52 with an empty selector
+      // (`\e]52;;<base64>\a`). The default BrowserClipboardProvider only
+      // responds to selector `c`, so tmux selections silently drop. Normalize
+      // empty/missing selector to `c` before delegating.
+      var TmuxAwareClipboardProvider = function () {};
+      TmuxAwareClipboardProvider.prototype = Object.create(
+        window.ClipboardAddon.BrowserClipboardProvider.prototype
+      );
+      TmuxAwareClipboardProvider.prototype.writeText = function (sel, text) {
+        return window.ClipboardAddon.BrowserClipboardProvider.prototype.writeText.call(
+          this, sel || 'c', text
+        );
+      };
+      TmuxAwareClipboardProvider.prototype.readText = function (sel) {
+        return window.ClipboardAddon.BrowserClipboardProvider.prototype.readText.call(
+          this, sel || 'c'
+        );
+      };
+      term.loadAddon(new window.ClipboardAddon.ClipboardAddon(
+        undefined, new TmuxAwareClipboardProvider()
+      ));
 
       // Store on tab
       tab.term = term;


### PR DESCRIPTION
## Summary
- Mouse selections inside a tmux pane were silently dropped when copied via OSC 52 through webssh. The fix lets the addon accept tmux's empty-selector OSC 52 format.
- `@xterm/addon-clipboard`'s default `BrowserClipboardProvider` only writes to the system clipboard when the OSC 52 selector field is exactly `c`. tmux emits `\e]52;;<base64>\a` (empty selector) on `copy-selection` / `set-buffer -w`, so the addon silently returned without writing.
- `main.js` now wraps `BrowserClipboardProvider` with a subclass that normalizes empty/missing selectors to `c` before delegating, and passes it into the `ClipboardAddon` constructor. No bundled JS is patched.

## Test plan
- [ ] Hard-refresh a webssh tab after deploy
- [ ] Attach to a tmux session with `set-clipboard on` and `xterm*:clipboard` in `terminal-features`
- [ ] Mouse-drag to select text in a tmux pane; confirm text lands in the system clipboard
- [ ] Run `tmux set-buffer -w "foo"`; confirm `foo` lands in the system clipboard
- [ ] Run `printf '\e]52;c;%s\a' "$(echo -n bar | base64)"` outside tmux (still-working baseline with explicit `c` selector)
- [ ] Confirm no regression: OSC 52 with selector `c` still writes to clipboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)