### PR TITLE
Ignore non-string postMessage payloads in cross_origin_connect

### DIFF
--- a/webssh/static/js/main.js
+++ b/webssh/static/js/main.js
@@ -1370,6 +1370,11 @@ jQuery(function($){
 
   function cross_origin_connect(event)
   {
+    // Browser extensions and other frames dispatch postMessage events with
+    // non-string payloads; only strings are meaningful to this handler.
+    if (typeof event.data !== 'string') {
+      return;
+    }
     console.log(event.origin);
     var prop = 'connect',
         args;


### PR DESCRIPTION
## Summary
- Browser extensions (React DevTools, MetaMask, Grammarly, etc.) and embedded frames routinely broadcast postMessage events with object payloads. The cross_origin_connect handler assumed event.data was always a string, so when JSON.parse threw it fell through to `event.data.split('|')` and raised `TypeError: event.data.split is not a function` in the console.
- Guard with `typeof event.data !== 'string'` so non-string payloads are silently ignored. This matches the handler's intent — it only acts on string-form connect args posted by the embedding page.

## Test plan
- [ ] Open webssh with browser devtools console visible
- [ ] Load a page with an extension that broadcasts postMessage (or do `window.postMessage({foo:1}, '*')` from the console)
- [ ] Confirm no TypeError is logged
- [ ] Confirm cross-origin embedding via `window.postMessage('host|port|...', '*')` still connects as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)