### PR TITLE
Let signed-in users manage their own hosts and settings

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -33,13 +33,24 @@ jobs:
       - run: pytest
 
   js:
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: ["20", "22", "24"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: "20"
-      - run: node --test tests/js/*.test.js
+          node-version: ${{ matrix.node-version }}
+      # `ls` fails loudly if the glob matches nothing, e.g. after a test
+      # file is renamed off *.test.js or moved into a subdirectory.
+      # Without it, an unmatched glob is passed through to `node --test`
+      # literally, which reports 0/0/0 passing and exits 0 -- a green,
+      # empty, silent gate. Note the glob is also NON-RECURSIVE: a future
+      # tests/js/<subdir>/*.test.js would not be picked up here and would
+      # need this pattern updated (e.g. to also glob tests/js/**/*.test.js).
+      - run: ls tests/js/*.test.js && node --test tests/js/*.test.js
 
   docker:
     needs: [lint, test, js]

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -13,7 +13,14 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-      - run: pip install ruff
+      # Pinned deliberately. An unpinned `pip install ruff` means every ruff
+      # release can turn this gate red without a code change, which is what
+      # happened on 0.16: it added rules (f-strings over .format(), no u''
+      # prefixes, bare super(), module loggers) that flag this codebase's
+      # long-standing Python-2-era style, producing 250 errors on main alone.
+      # Upgrading the pin is fine, but it means taking on that modernisation
+      # in one deliberate pass rather than discovering it mid-review.
+      - run: pip install ruff==0.15.6
       - run: ruff check .
 
   test:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -39,7 +39,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: "20"
-      - run: node --test tests/js/
+      - run: node --test tests/js/*.test.js
 
   docker:
     needs: [lint, test, js]

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -32,8 +32,17 @@ jobs:
       - run: pip install pytest -r requirements.txt
       - run: pytest
 
+  js:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - run: node --test tests/js/
+
   docker:
-    needs: [lint, test]
+    needs: [lint, test, js]
     runs-on: ubuntu-latest
     permissions:
       packages: write

--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,6 @@ known_hosts
 
 data/
 .venv/
+
+# SDD scratch workspace
+.superpowers/

--- a/README.md
+++ b/README.md
@@ -116,7 +116,10 @@ trusted_proxies:
 
 Administrator hosts from `hosts:` remain read-only and always take precedence: if
 a user saves a host with the same hostname and port as an administrator entry,
-the administrator's host key pin is the one used.
+the user's entry is dropped in its entirety and only the administrator's entry
+is used — its host key pins, its username, and its default command. The user's
+colliding entry still appears in their Settings tab, but it has no effect on
+connections.
 
 Requires an auth proxy that sets a username header; without one, `user_hosts`
 has no effect. Set `trusted_proxies` so the header can't be spoofed — without

--- a/README.md
+++ b/README.md
@@ -195,3 +195,14 @@ Run tests:
 pip install pytest
 python -m pytest tests
 ```
+
+Browser client tests require Node 20+ and install nothing:
+
+```bash
+node --test tests/js/*.test.js
+```
+
+They cover the pure decision logic in `webssh/static/js/user-hosts.js` — host
+payload construction, port validation, settings merging, preference precedence,
+and the legacy command migration. DOM behaviour in `main.js` (tab lifecycle, the
+hostname input/select upgrade, asynchronous save sequencing) is not covered.

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Built on Python, Tornado, Paramiko, and xterm.js.
 * Password and public-key authentication (RSA, ECDSA, Ed25519)
 * Encrypted keys and TOTP two-factor authentication
 * Per-user server-side SSH key generation and storage
+* Per-user host lists and preferences that roam across browsers and machines
 * YAML configuration with host allowlisting and host key pinning
 * Hostname:port shortcut in the connect form
 * Username pre-filled from auth proxy header
@@ -91,6 +92,38 @@ python scripts/known_hosts_to_yaml.py ~/.ssh/known_hosts > config.yaml
 When `userkeydir` is configured, authenticated users can generate Ed25519 key pairs on the server and use them for connections without uploading a key file each time. The user's public key is displayed in the UI for copying to `authorized_keys` on target hosts.
 
 Requires an auth proxy (e.g. Authentik) that sets a username header.
+
+### User-managed hosts
+
+With `user_hosts: true`, each authenticated user gets a Settings tab where they
+can add their own hosts and set terminal preferences. Both are stored on the
+server under `userdatadir` (defaulting to `userkeydir`), so they follow the user
+between browsers and machines.
+
+**The `hosts:` allowlist above is a security boundary: it is the only thing
+stopping an authenticated user from connecting anywhere. Turning on
+`user_hosts` lets users add their own hosts outside that allowlist, so it stops
+being a hard restriction.** If you rely on `hosts:` to restrict where users can
+connect, leave `user_hosts` off.
+
+```yaml
+user_hosts: true
+userdatadir: /var/lib/webssh/user-data
+userheader: X-Authentik-Username
+trusted_proxies:
+  - 10.0.0.1
+```
+
+Administrator hosts from `hosts:` remain read-only and always take precedence: if
+a user saves a host with the same hostname and port as an administrator entry,
+the administrator's host key pin is the one used.
+
+Requires an auth proxy that sets a username header; without one, `user_hosts`
+has no effect. Set `trusted_proxies` so the header can't be spoofed — without
+it, any client can claim any username and reach that user's stored hosts.
+
+Secrets (passwords, TOTP codes, key passphrases) are never stored server-side,
+whether for administrator or personal hosts.
 
 ### Docker Compose
 

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -31,6 +31,25 @@
 # Used with userkeydir to identify users behind an auth proxy (e.g. Authentik).
 # userheader: X-Authentik-Username
 
+# User-managed hosts and settings (optional)
+# When true, authenticated users can add their own hosts and manage terminal
+# preferences from the in-app Settings tab. Their hosts and settings are stored
+# server-side so they roam across browsers and machines.
+#
+# SECURITY: enabling this lets users connect to hosts outside the `hosts`
+# allowlist above. Leave it false if the allowlist is meant to be a hard
+# restriction. Personal hosts can pin their own host_key, which is required
+# when policy is `reject`.
+#
+# Requires an authenticated username via userheader. Set trusted_proxies so the
+# header cannot be spoofed.
+# user_hosts: true
+
+# Directory for per-user hosts and settings (optional)
+# Defaults to userkeydir when unset, placing hosts.json and settings.json
+# alongside each user's SSH key.
+# userdatadir: /var/lib/webssh/user-data
+
 # Idle timeout in seconds (optional)
 # Disconnect websocket sessions that have been idle (no keystrokes) for this
 # many seconds. Set to 0 to disable. Default: 1800 (30 minutes).

--- a/docs/superpowers/plans/2026-07-27-user-editable-hosts.md
+++ b/docs/superpowers/plans/2026-07-27-user-editable-hosts.md
@@ -1158,7 +1158,8 @@ is supplied the same way production does it — through a config file — becaus
 `options.config`:
 
 ```python
-class TestConnectWithUserHosts(UserDataTestBase):
+class ConnectHostsTestBase(UserDataTestBase):
+    """Admin allowlist that deliberately excludes the user's saved host."""
 
     admin_hostname = '10.9.9.9'
 
@@ -1177,39 +1178,46 @@ class TestConnectWithUserHosts(UserDataTestBase):
 
     def tearDown(self):
         os.unlink(self.config_path)
-        super(TestConnectWithUserHosts, self).tearDown()
+        super(ConnectHostsTestBase, self).tearDown()
+
+    def post_hostname(self, hostname):
+        body = ('hostname={}&port=7000&username=robey&password=foo'
+                '&_xsrf=yummy').format(hostname)
+        return self.fetch('/', method='POST', body=body,
+                          headers=self.headers)
+
+
+class TestConnectWithUserHostsEnabled(ConnectHostsTestBase):
+
+    user_hosts = True
 
     def test_user_host_passes_the_allowlist(self):
-        body = ('hostname=127.0.0.1&port=7000&username=robey&password=foo'
-                '&_xsrf=yummy')
-        response = self.fetch('/', method='POST', body=body,
-                              headers=self.headers)
         # The allowlist must not reject it. The SSH connection itself will
         # fail (no server on that port), which is fine and not what we assert.
-        self.assertNotIn(b'is not allowed', response.body)
+        self.assertNotIn(b'is not allowed',
+                         self.post_hostname('127.0.0.1').body)
 
     def test_host_in_neither_list_is_rejected(self):
-        body = ('hostname=127.0.0.2&port=7000&username=robey&password=foo'
-                '&_xsrf=yummy')
-        response = self.fetch('/', method='POST', body=body,
-                              headers=self.headers)
-        self.assertIn(b'is not allowed', response.body)
+        self.assertIn(b'is not allowed',
+                      self.post_hostname('127.0.0.2').body)
 
 
-class TestConnectWithUserHostsDisabled(TestConnectWithUserHosts):
+class TestConnectWithUserHostsDisabled(ConnectHostsTestBase):
 
     user_hosts = False
 
     def test_user_host_is_rejected_when_feature_disabled(self):
-        body = ('hostname=127.0.0.1&port=7000&username=robey&password=foo'
-                '&_xsrf=yummy')
-        response = self.fetch('/', method='POST', body=body,
-                              headers=self.headers)
-        self.assertIn(b'is not allowed', response.body)
+        self.assertIn(b'is not allowed',
+                      self.post_hostname('127.0.0.1').body)
 
-    def test_user_host_passes_the_allowlist(self):
-        pass  # inverted above; the enabled-case assertion does not apply
+    def test_host_in_neither_list_is_rejected(self):
+        self.assertIn(b'is not allowed',
+                      self.post_hostname('127.0.0.2').body)
 ```
+
+Note the shape: a shared base holds the fixture, and each concrete class
+asserts its own behavior. No test inherits an assertion that does not apply to
+it, and no test body is empty.
 
 `tests/test_app.py` imports `json` but not `os`, so add `import os` too (Task 4
 already added `tempfile` and `unittest`).

--- a/docs/superpowers/plans/2026-07-27-user-editable-hosts.md
+++ b/docs/superpowers/plans/2026-07-27-user-editable-hosts.md
@@ -1,0 +1,2379 @@
+# User-Editable Host List and Roaming Settings — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let each signed-in user maintain a private list of SSH hosts and a set of preferences, stored server-side so they roam across browsers and machines.
+
+**Architecture:** A new `webssh/user_data.py` stores per-user JSON under `<userdatadir>/<username>/`, mirroring how `user_keys.py` already stores per-user SSH keys. Two JSON APIs read and write it. `IndexHandler` merges the user's hosts with the administrator allowlist at connect time, with administrator entries winning collisions. The UI is a settings tab inside the existing in-app tab bar, fed by a server-rendered HTML fragment.
+
+**Tech Stack:** Python 3, Tornado, Paramiko, PyYAML, jQuery, xterm.js. No new dependencies.
+
+**Spec:** `docs/superpowers/specs/2026-07-27-user-editable-hosts-design.md`
+
+## Global Constraints
+
+- **No new dependencies.** Everything needed is already in `requirements.txt`.
+- **Match existing code style.** The codebase uses `'{}'.format(x)` rather than f-strings, `super(ClassName, self).__init__(...)` rather than bare `super()`, and `u''` string literals in handler argument defaults. Follow it; do not modernize surrounding code.
+- **JavaScript is ES5 + jQuery.** `webssh/static/js/main.js` uses `var`, no arrow functions, no `const`/`let`, no modules. Match it.
+- **Tests run with pytest** but are written as `unittest.TestCase` (or `tornado.testing.AsyncHTTPTestCase` for handlers). Run with `.venv/bin/python -m pytest`.
+- **Never persist secrets.** Passwords, TOTP codes, and key passphrases must never reach `user_data.py` or any stored JSON. Validation whitelists fields, so unknown keys are dropped rather than stored.
+- **Backward compatibility is mandatory.** With `user_hosts` unset or false, every existing behavior must be byte-for-byte unchanged. The full existing suite must stay green after every task.
+- **Feature gate:** active only when `user_hosts` is true AND a data directory resolves AND the request carries a username in the `userheader` header.
+- **Internal host key field naming:** YAML and JSON input use `host_key`; the parsed/normalized dict uses `host_keys` (plural, always a list). This asymmetry already exists in `parse_allowed_hosts` — preserve it.
+
+**Baseline:** the suite is green at 152 passed. Verify with `.venv/bin/python -m pytest -q` before starting. If you see ~53 failures mentioning paramiko and `known_hosts`, your `~/.ssh/known_hosts` contains a malformed line; that is an environment problem, not a regression.
+
+---
+
+### Task 1: Extract single-host parsing in settings.py
+
+Administrator hosts and user hosts must be validated by identical code, so a user cannot submit a host key pin an administrator could not. Right now that logic is inlined in the `parse_allowed_hosts` loop. This task extracts it with no behavior change.
+
+**Files:**
+- Modify: `webssh/settings.py:286-323` (`parse_allowed_hosts`)
+- Test: `tests/test_settings.py`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `parse_host_entry(entry)` in `webssh/settings.py`. Takes a dict, returns a new dict `{'name': str, 'hostname': str, 'port': int, 'host_keys': list[str]}`, raises `ValueError` on any invalid field. Tasks 2 and 4 both call it.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/test_settings.py`:
+
+```python
+class TestParseHostEntry(unittest.TestCase):
+
+    def test_minimal_entry(self):
+        from webssh.settings import parse_host_entry
+        host = parse_host_entry({'hostname': 'example.com'})
+        self.assertEqual(host, {
+            'name': 'example.com',
+            'hostname': 'example.com',
+            'port': 22,
+            'host_keys': [],
+        })
+
+    def test_full_entry_with_string_host_key(self):
+        from webssh.settings import parse_host_entry
+        key = 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIAbcdefgh'
+        host = parse_host_entry({
+            'name': 'Prod', 'hostname': '10.0.1.5', 'port': 2222,
+            'host_key': key,
+        })
+        self.assertEqual(host['name'], 'Prod')
+        self.assertEqual(host['port'], 2222)
+        self.assertEqual(host['host_keys'], [key])
+
+    def test_missing_hostname(self):
+        from webssh.settings import parse_host_entry
+        with self.assertRaises(ValueError):
+            parse_host_entry({'name': 'nope'})
+
+    def test_not_a_mapping(self):
+        from webssh.settings import parse_host_entry
+        with self.assertRaises(ValueError):
+            parse_host_entry('example.com')
+
+    def test_invalid_port(self):
+        from webssh.settings import parse_host_entry
+        for port in [0, 70000, -1]:
+            with self.assertRaises(ValueError):
+                parse_host_entry({'hostname': 'a.com', 'port': port})
+
+    def test_invalid_host_key_type(self):
+        from webssh.settings import parse_host_entry
+        with self.assertRaises(ValueError):
+            parse_host_entry({
+                'hostname': 'a.com', 'host_key': 'ssh-dss AAAAB3Nz'})
+
+    def test_invalid_host_key_base64(self):
+        from webssh.settings import parse_host_entry
+        with self.assertRaises(ValueError):
+            parse_host_entry({
+                'hostname': 'a.com', 'host_key': 'ssh-ed25519 not!base64!'})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/bin/python -m pytest tests/test_settings.py::TestParseHostEntry -v`
+Expected: FAIL with `ImportError: cannot import name 'parse_host_entry'`
+
+- [ ] **Step 3: Extract the function**
+
+In `webssh/settings.py`, add `parse_host_entry` immediately above `parse_allowed_hosts`. The body is lifted verbatim from the existing loop:
+
+```python
+def parse_host_entry(entry):
+    if not isinstance(entry, dict):
+        raise ValueError('Each host entry must be a mapping')
+    if 'hostname' not in entry:
+        raise ValueError('Each host entry must have a "hostname" field')
+    raw_keys = entry.get('host_key', [])
+    if isinstance(raw_keys, str):
+        raw_keys = [raw_keys] if raw_keys else []
+    elif not isinstance(raw_keys, list):
+        raise ValueError(
+            'host_key for {!r} must be a string or list'.format(
+                entry['hostname'])
+        )
+    for k in raw_keys:
+        _validate_host_key(k, entry['hostname'])
+    try:
+        port = int(entry.get('port', 22))
+    except (TypeError, ValueError):
+        raise ValueError(
+            'Invalid port {!r} for host {!r}; must be 1-65535'.format(
+                entry.get('port'), entry['hostname'])
+        )
+    if port < 1 or port > 65535:
+        raise ValueError(
+            'Invalid port {!r} for host {!r}; must be 1-65535'.format(
+                port, entry['hostname'])
+        )
+    return {
+        'name': entry.get('name', entry['hostname']),
+        'hostname': entry['hostname'],
+        'port': port,
+        'host_keys': raw_keys,
+    }
+```
+
+Then replace the loop body in `parse_allowed_hosts` so the whole function reads:
+
+```python
+def parse_allowed_hosts(data):
+    if 'hosts' not in data:
+        return []
+
+    hosts = data['hosts']
+    if not isinstance(hosts, list) or not hosts:
+        raise ValueError(
+            'Config file "hosts" must be a non-empty list'
+        )
+
+    return [parse_host_entry(entry) for entry in hosts]
+```
+
+Note the one deliberate improvement: the original `int(entry.get('port', 22))` raised an uncaught `TypeError`/`ValueError` on a non-numeric port such as `port: abc`. It is now wrapped to raise `ValueError` with a clear message, which is what every caller already expects.
+
+- [ ] **Step 4: Run the new tests and the full suite**
+
+Run: `.venv/bin/python -m pytest tests/test_settings.py::TestParseHostEntry -v`
+Expected: PASS (7 tests)
+
+Run: `.venv/bin/python -m pytest -q`
+Expected: PASS, 159 passed. No existing test may fail — this is a pure refactor.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add webssh/settings.py tests/test_settings.py
+git commit -m "refactor: extract parse_host_entry from parse_allowed_hosts"
+```
+
+---
+
+### Task 2: Per-user storage module
+
+**Files:**
+- Create: `webssh/user_data.py`
+- Test: `tests/test_user_data.py`
+
+**Interfaces:**
+- Consumes: `parse_host_entry` from Task 1.
+- Produces, all in `webssh.user_data`:
+  - `SCHEMA_VERSION = 1`
+  - `get_user_data_dir(base_dir, username)` → absolute path, raises `ValueError`
+  - `read_hosts(base_dir, username)` → `list[dict]`, `[]` when missing or corrupt
+  - `write_hosts(base_dir, username, hosts)` → `list[dict]` (the normalized list written)
+  - `read_settings(base_dir, username)` → `dict`, `{}` when missing or corrupt
+  - `write_settings(base_dir, username, settings)` → `dict` (the normalized dict written)
+  - `validate_hosts(hosts)` → `list[dict]`, raises `ValueError`
+  - `validate_settings(settings)` → `dict`, raises `ValueError`
+
+A stored host dict has the four keys from `parse_host_entry` plus the two user-only keys `username` and `default_command`, which are always present as strings (empty string when unset).
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/test_user_data.py`:
+
+```python
+import json
+import os
+import stat
+import tempfile
+import unittest
+
+from webssh.user_data import (
+    SCHEMA_VERSION, get_user_data_dir, read_hosts, write_hosts,
+    read_settings, write_settings, validate_hosts, validate_settings
+)
+
+
+VALID_KEY = 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIAbcdefgh'
+
+
+class TestGetUserDataDir(unittest.TestCase):
+
+    def setUp(self):
+        self.base = tempfile.mkdtemp()
+
+    def test_valid_username(self):
+        path = get_user_data_dir(self.base, 'alice')
+        self.assertTrue(path.endswith(os.sep + 'alice'))
+
+    def test_path_traversal_rejected(self):
+        for name in ['../etc', 'foo/bar', '..', '.hidden', '']:
+            with self.assertRaises(ValueError):
+                get_user_data_dir(self.base, name)
+
+
+class TestValidateHosts(unittest.TestCase):
+
+    def test_normalizes_minimal_host(self):
+        result = validate_hosts([{'hostname': 'nas.lan'}])
+        self.assertEqual(result, [{
+            'name': 'nas.lan', 'hostname': 'nas.lan', 'port': 22,
+            'host_keys': [], 'username': '', 'default_command': '',
+        }])
+
+    def test_keeps_user_only_fields(self):
+        result = validate_hosts([{
+            'hostname': 'nas.lan', 'port': 2222, 'name': 'homelab',
+            'host_key': VALID_KEY, 'username': 'ryan',
+            'default_command': 'tmux attach',
+        }])
+        self.assertEqual(result[0]['username'], 'ryan')
+        self.assertEqual(result[0]['default_command'], 'tmux attach')
+        self.assertEqual(result[0]['host_keys'], [VALID_KEY])
+
+    def test_drops_unknown_fields(self):
+        result = validate_hosts([{'hostname': 'a.com', 'password': 'hunter2'}])
+        self.assertNotIn('password', result[0])
+
+    def test_rejects_non_list(self):
+        with self.assertRaises(ValueError):
+            validate_hosts({'hostname': 'a.com'})
+
+    def test_rejects_bad_port(self):
+        with self.assertRaises(ValueError):
+            validate_hosts([{'hostname': 'a.com', 'port': 99999}])
+
+    def test_rejects_bad_host_key(self):
+        with self.assertRaises(ValueError):
+            validate_hosts([{'hostname': 'a.com', 'host_key': 'ssh-dss AAAA'}])
+
+    def test_rejects_non_string_user_fields(self):
+        with self.assertRaises(ValueError):
+            validate_hosts([{'hostname': 'a.com', 'username': 42}])
+
+    def test_rejects_too_many_hosts(self):
+        with self.assertRaises(ValueError):
+            validate_hosts([{'hostname': 'h{}.com'.format(i)}
+                            for i in range(201)])
+
+    def test_empty_list_is_valid(self):
+        self.assertEqual(validate_hosts([]), [])
+
+
+class TestValidateSettings(unittest.TestCase):
+
+    def test_accepts_known_settings(self):
+        result = validate_settings({
+            'font_size': 14, 'background': '#000000', 'foreground': '#ffffff',
+            'cursor': '#00ff00', 'cursor_blink': True, 'encoding': 'utf-8',
+            'term': 'xterm-256color', 'key_source': 'stored',
+            'last_hostname': 'nas.lan', 'last_username': 'ryan',
+            'last_port': 2222,
+        })
+        self.assertEqual(result['font_size'], 14)
+        self.assertEqual(result['key_source'], 'stored')
+        self.assertEqual(result['last_port'], 2222)
+
+    def test_drops_secrets_and_unknown_keys(self):
+        result = validate_settings({
+            'password': 'hunter2', 'credential': 'x', 'totp': '123456',
+            'passphrase': 'y', 'privatekey': 'z', 'font_size': 12,
+        })
+        self.assertEqual(result, {'font_size': 12})
+
+    def test_rejects_non_mapping(self):
+        with self.assertRaises(ValueError):
+            validate_settings(['font_size', 12])
+
+    def test_rejects_out_of_range_font_size(self):
+        for size in [0, 5, 200]:
+            with self.assertRaises(ValueError):
+                validate_settings({'font_size': size})
+
+    def test_rejects_bad_color(self):
+        for color in ['javascript:alert(1)', '#12', 'red;x', 123]:
+            with self.assertRaises(ValueError):
+                validate_settings({'background': color})
+
+    def test_accepts_named_and_hex_colors(self):
+        for color in ['black', 'white', '#fff', '#00ff00']:
+            self.assertEqual(
+                validate_settings({'background': color})['background'], color)
+
+    def test_rejects_bad_key_source(self):
+        with self.assertRaises(ValueError):
+            validate_settings({'key_source': 'somewhere-else'})
+
+    def test_rejects_bad_encoding(self):
+        with self.assertRaises(ValueError):
+            validate_settings({'encoding': 'not-a-real-encoding'})
+
+
+class TestRoundTrip(unittest.TestCase):
+
+    def setUp(self):
+        self.base = tempfile.mkdtemp()
+
+    def test_hosts_round_trip(self):
+        written = write_hosts(self.base, 'alice', [{'hostname': 'nas.lan'}])
+        self.assertEqual(read_hosts(self.base, 'alice'), written)
+
+    def test_settings_round_trip(self):
+        written = write_settings(self.base, 'alice', {'font_size': 16})
+        self.assertEqual(read_settings(self.base, 'alice'), written)
+        self.assertEqual(written, {'font_size': 16})
+
+    def test_read_missing_returns_empty(self):
+        self.assertEqual(read_hosts(self.base, 'nobody'), [])
+        self.assertEqual(read_settings(self.base, 'nobody'), {})
+
+    def test_read_corrupt_returns_empty(self):
+        user_dir = get_user_data_dir(self.base, 'alice')
+        os.makedirs(user_dir, mode=0o700)
+        with open(os.path.join(user_dir, 'hosts.json'), 'w') as f:
+            f.write('{not json at all')
+        self.assertEqual(read_hosts(self.base, 'alice'), [])
+
+    def test_read_wrong_shape_returns_empty(self):
+        user_dir = get_user_data_dir(self.base, 'alice')
+        os.makedirs(user_dir, mode=0o700)
+        with open(os.path.join(user_dir, 'hosts.json'), 'w') as f:
+            json.dump({'version': 1, 'hosts': 'not-a-list'}, f)
+        self.assertEqual(read_hosts(self.base, 'alice'), [])
+
+    def test_written_file_has_version_and_mode(self):
+        write_hosts(self.base, 'alice', [{'hostname': 'nas.lan'}])
+        path = os.path.join(get_user_data_dir(self.base, 'alice'), 'hosts.json')
+        with open(path) as f:
+            raw = json.load(f)
+        self.assertEqual(raw['version'], SCHEMA_VERSION)
+        self.assertIsInstance(raw['hosts'], list)
+        mode = stat.S_IMODE(os.stat(path).st_mode)
+        self.assertEqual(mode, 0o600)
+
+    def test_invalid_write_leaves_previous_data(self):
+        write_hosts(self.base, 'alice', [{'hostname': 'good.lan'}])
+        with self.assertRaises(ValueError):
+            write_hosts(self.base, 'alice', [{'hostname': 'bad', 'port': 0}])
+        stored = read_hosts(self.base, 'alice')
+        self.assertEqual(len(stored), 1)
+        self.assertEqual(stored[0]['hostname'], 'good.lan')
+
+    def test_write_leaves_no_temp_files(self):
+        write_hosts(self.base, 'alice', [{'hostname': 'nas.lan'}])
+        entries = os.listdir(get_user_data_dir(self.base, 'alice'))
+        self.assertEqual(sorted(entries), ['hosts.json'])
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `.venv/bin/python -m pytest tests/test_user_data.py -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'webssh.user_data'`
+
+- [ ] **Step 3: Write the module**
+
+Create `webssh/user_data.py`:
+
+```python
+import json
+import logging
+import os
+import re
+import tempfile
+
+from webssh.settings import parse_host_entry
+from webssh.user_keys import sanitize_username
+from webssh.utils import is_valid_encoding
+
+
+SCHEMA_VERSION = 1
+MAX_HOSTS = 200
+MAX_FIELD_LENGTH = 512
+
+HOSTS_FILENAME = 'hosts.json'
+SETTINGS_FILENAME = 'settings.json'
+
+COLOR_RE = re.compile(r'^(#[0-9a-fA-F]{3}|#[0-9a-fA-F]{6}|[a-zA-Z]{1,20})$')
+TERM_RE = re.compile(r'^[a-zA-Z0-9._-]{1,32}$')
+
+# Only these keys are ever persisted. Anything else — notably passwords,
+# TOTP codes, and passphrases — is dropped.
+COLOR_SETTINGS = ('background', 'foreground', 'cursor')
+STRING_SETTINGS = ('last_hostname', 'last_username')
+
+
+def get_user_data_dir(base_dir, username):
+    sanitize_username(username)
+    user_dir = os.path.join(base_dir, username)
+    real_base = os.path.realpath(base_dir)
+    real_user = os.path.realpath(user_dir)
+    if not real_user.startswith(real_base + os.sep):
+        raise ValueError('Invalid username.')
+    return real_user
+
+
+def _check_string(value, name, allow_empty=True):
+    if not isinstance(value, str):
+        raise ValueError('{} must be a string'.format(name))
+    if len(value) > MAX_FIELD_LENGTH:
+        raise ValueError('{} is too long'.format(name))
+    if not allow_empty and not value:
+        raise ValueError('{} must not be empty'.format(name))
+    return value
+
+
+def validate_hosts(hosts):
+    if not isinstance(hosts, list):
+        raise ValueError('hosts must be a list')
+    if len(hosts) > MAX_HOSTS:
+        raise ValueError('Too many hosts; the limit is {}'.format(MAX_HOSTS))
+
+    result = []
+    for entry in hosts:
+        host = parse_host_entry(entry)
+        host['username'] = _check_string(
+            entry.get('username', ''), 'username')
+        host['default_command'] = _check_string(
+            entry.get('default_command', ''), 'default_command')
+        result.append(host)
+    return result
+
+
+def validate_settings(settings):
+    if not isinstance(settings, dict):
+        raise ValueError('settings must be a mapping')
+
+    result = {}
+
+    if 'font_size' in settings:
+        value = settings['font_size']
+        if isinstance(value, bool) or not isinstance(value, int):
+            raise ValueError('font_size must be an integer')
+        if value < 6 or value > 40:
+            raise ValueError('font_size must be between 6 and 40')
+        result['font_size'] = value
+
+    for name in COLOR_SETTINGS:
+        if name in settings:
+            value = settings[name]
+            if not isinstance(value, str) or not COLOR_RE.match(value):
+                raise ValueError('Invalid color for {}'.format(name))
+            result[name] = value
+
+    if 'cursor_blink' in settings:
+        value = settings['cursor_blink']
+        if not isinstance(value, bool):
+            raise ValueError('cursor_blink must be a boolean')
+        result['cursor_blink'] = value
+
+    if 'encoding' in settings:
+        value = settings['encoding']
+        if not isinstance(value, str) or not is_valid_encoding(value):
+            raise ValueError('Invalid encoding {!r}'.format(value))
+        result['encoding'] = value
+
+    if 'term' in settings:
+        value = settings['term']
+        if not isinstance(value, str) or not TERM_RE.match(value):
+            raise ValueError('Invalid term {!r}'.format(value))
+        result['term'] = value
+
+    if 'key_source' in settings:
+        value = settings['key_source']
+        if value not in ('stored', 'upload'):
+            raise ValueError('key_source must be "stored" or "upload"')
+        result['key_source'] = value
+
+    for name in STRING_SETTINGS:
+        if name in settings:
+            result[name] = _check_string(settings[name], name)
+
+    if 'last_port' in settings:
+        value = settings['last_port']
+        if isinstance(value, bool) or not isinstance(value, int):
+            raise ValueError('last_port must be an integer')
+        if value < 1 or value > 65535:
+            raise ValueError('last_port must be between 1 and 65535')
+        result['last_port'] = value
+
+    return result
+
+
+def _read_json(base_dir, username, filename, payload_key, empty):
+    user_dir = get_user_data_dir(base_dir, username)
+    path = os.path.join(user_dir, filename)
+    if not os.path.isfile(path):
+        return empty
+    try:
+        with open(path, 'r') as f:
+            data = json.load(f)
+    except (ValueError, OSError) as exc:
+        logging.warning(
+            'Ignoring unreadable {} for user {!r}: {}'.format(
+                filename, username, exc)
+        )
+        return empty
+    if not isinstance(data, dict):
+        logging.warning(
+            'Ignoring malformed {} for user {!r}'.format(filename, username))
+        return empty
+    payload = data.get(payload_key, empty)
+    if not isinstance(payload, type(empty)):
+        logging.warning(
+            'Ignoring malformed {} for user {!r}'.format(filename, username))
+        return empty
+    return payload
+
+
+def _write_json(base_dir, username, filename, payload_key, payload):
+    user_dir = get_user_data_dir(base_dir, username)
+    try:
+        os.makedirs(user_dir, mode=0o700, exist_ok=True)
+    except PermissionError:
+        raise ValueError(
+            'Cannot create data directory for user {!r}: permission denied. '
+            'Check ownership of {!r}'.format(username, base_dir)
+        )
+
+    body = json.dumps(
+        {'version': SCHEMA_VERSION, payload_key: payload}, indent=2
+    ).encode()
+
+    path = os.path.join(user_dir, filename)
+    fd, tmp_path = tempfile.mkstemp(dir=user_dir)
+    closed = False
+    try:
+        os.write(fd, body)
+        os.fchmod(fd, 0o600)
+        os.close(fd)
+        closed = True
+        os.rename(tmp_path, path)
+    except Exception:
+        os.unlink(tmp_path)
+        raise
+    finally:
+        if not closed:
+            try:
+                os.close(fd)
+            except OSError:
+                pass
+
+
+def read_hosts(base_dir, username):
+    return _read_json(base_dir, username, HOSTS_FILENAME, 'hosts', [])
+
+
+def write_hosts(base_dir, username, hosts):
+    validated = validate_hosts(hosts)
+    _write_json(base_dir, username, HOSTS_FILENAME, 'hosts', validated)
+    return validated
+
+
+def read_settings(base_dir, username):
+    return _read_json(base_dir, username, SETTINGS_FILENAME, 'settings', {})
+
+
+def write_settings(base_dir, username, settings):
+    validated = validate_settings(settings)
+    _write_json(
+        base_dir, username, SETTINGS_FILENAME, 'settings', validated)
+    return validated
+```
+
+Note two ordering details that make the atomicity tests pass: validation runs before any file is touched, so a rejected write leaves prior data intact; and `os.rename` over the same filesystem is atomic, so a reader never sees a partial file.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `.venv/bin/python -m pytest tests/test_user_data.py -v`
+Expected: PASS (all tests)
+
+Run: `.venv/bin/python -m pytest -q`
+Expected: PASS, no regressions.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add webssh/user_data.py tests/test_user_data.py
+git commit -m "feat: add per-user host and settings storage module"
+```
+
+---
+
+### Task 3: Configuration plumbing
+
+**Files:**
+- Modify: `webssh/settings.py` — add options near line 61, add `check_user_data_dir` after `check_user_key_dir` (line 396), extend `apply_config_settings` (line 351)
+- Modify: `webssh/main.py:171-197` (`main`)
+- Test: `tests/test_settings.py`
+
+**Interfaces:**
+- Consumes: nothing from prior tasks.
+- Produces:
+  - Tornado options `user_hosts` (bool, default `False`) and `userdatadir` (str, default `''`)
+  - `get_user_data_dir_setting(options)` → `str`; returns `options.userdatadir` if set, else `options.userkeydir`, else `''`
+  - `check_user_data_dir(user_data_dir, tdstream='')` → creates the directory, raises `ValueError` on failure, logs the spoofable-header warning when `tdstream` is empty
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `tests/test_settings.py`:
+
+```python
+class TestUserDataSettings(unittest.TestCase):
+
+    def test_userdatadir_falls_back_to_userkeydir(self):
+        from webssh.settings import get_user_data_dir_setting
+
+        class Opts(object):
+            userdatadir = ''
+            userkeydir = '/var/lib/webssh/keys'
+
+        self.assertEqual(get_user_data_dir_setting(Opts()),
+                         '/var/lib/webssh/keys')
+
+    def test_userdatadir_wins_when_set(self):
+        from webssh.settings import get_user_data_dir_setting
+
+        class Opts(object):
+            userdatadir = '/var/lib/webssh/data'
+            userkeydir = '/var/lib/webssh/keys'
+
+        self.assertEqual(get_user_data_dir_setting(Opts()),
+                         '/var/lib/webssh/data')
+
+    def test_userdatadir_empty_when_neither_set(self):
+        from webssh.settings import get_user_data_dir_setting
+
+        class Opts(object):
+            userdatadir = ''
+            userkeydir = ''
+
+        self.assertEqual(get_user_data_dir_setting(Opts()), '')
+
+    def test_check_user_data_dir_creates_directory(self):
+        import tempfile
+        from webssh.settings import check_user_data_dir
+        base = tempfile.mkdtemp()
+        target = os.path.join(base, 'data')
+        check_user_data_dir(target, tdstream='10.0.0.1')
+        self.assertTrue(os.path.isdir(target))
+
+    def test_check_user_data_dir_noop_when_empty(self):
+        from webssh.settings import check_user_data_dir
+        self.assertIsNone(check_user_data_dir(''))
+
+    def test_check_user_data_dir_rejects_file(self):
+        import tempfile
+        from webssh.settings import check_user_data_dir
+        fd, path = tempfile.mkstemp()
+        os.close(fd)
+        with self.assertRaises(ValueError):
+            check_user_data_dir(path, tdstream='10.0.0.1')
+
+
+class TestApplyUserHostsConfig(unittest.TestCase):
+
+    def test_user_hosts_and_userdatadir_from_config(self):
+        import tempfile
+        import yaml
+        from tornado.options import options as opts
+        from webssh.settings import apply_config_settings
+
+        fd, path = tempfile.mkstemp(suffix='.yaml')
+        with os.fdopen(fd, 'w') as f:
+            yaml.safe_dump({
+                'user_hosts': True, 'userdatadir': '/tmp/webssh-data'}, f)
+
+        old_config = opts.config
+        old_flag = opts.user_hosts
+        old_dir = opts.userdatadir
+        try:
+            opts.config = path
+            apply_config_settings(opts)
+            self.assertTrue(opts.user_hosts)
+            self.assertEqual(opts.userdatadir, '/tmp/webssh-data')
+        finally:
+            opts.config = old_config
+            opts.user_hosts = old_flag
+            opts.userdatadir = old_dir
+            os.unlink(path)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `.venv/bin/python -m pytest tests/test_settings.py::TestUserDataSettings tests/test_settings.py::TestApplyUserHostsConfig -v`
+Expected: FAIL with `ImportError: cannot import name 'get_user_data_dir_setting'`
+
+- [ ] **Step 3: Add the options and helpers**
+
+In `webssh/settings.py`, directly after the `userheader` definition at line 61:
+
+```python
+define('userdatadir', default='',
+       help='Directory for per-user hosts and settings '
+            '(defaults to userkeydir)')
+define('user_hosts', type=bool, default=False,
+       help='Allow authenticated users to manage their own host list')
+```
+
+Add after `check_user_key_dir`:
+
+```python
+def get_user_data_dir_setting(options):
+    return options.userdatadir or options.userkeydir or ''
+
+
+def check_user_data_dir(user_data_dir, tdstream=''):
+    if not user_data_dir:
+        return
+    if not tdstream:
+        logging.warning(
+            'SECURITY WARNING: user_hosts is enabled but no trusted_proxies '
+            'configured. The user header can be spoofed by any client.'
+        )
+    try:
+        os.makedirs(user_data_dir, mode=0o700, exist_ok=True)
+    except PermissionError:
+        raise ValueError(
+            'Cannot create user data directory {!r}: permission denied. '
+            'Create the directory manually or run with appropriate '
+            'permissions.'.format(user_data_dir)
+        )
+    except (FileExistsError, NotADirectoryError):
+        raise ValueError(
+            'User data directory {!r} is not a directory'.format(user_data_dir)
+        )
+    if not os.path.isdir(user_data_dir):
+        raise ValueError(
+            'User data directory {!r} is not a directory'.format(user_data_dir)
+        )
+```
+
+In `apply_config_settings`, after the `userheader` block at line 360:
+
+```python
+    if not options.userdatadir and 'userdatadir' in config:
+        options.userdatadir = config['userdatadir']
+    if not options.user_hosts and 'user_hosts' in config:
+        options.user_hosts = bool(config['user_hosts'])
+```
+
+- [ ] **Step 4: Wire it into startup**
+
+In `webssh/main.py`, extend the import from `webssh.settings` (lines 15-20) with `get_user_data_dir_setting` and `check_user_data_dir`, then in `main()` immediately after the existing `check_user_key_dir` call at line 178:
+
+```python
+    user_data_dir = get_user_data_dir_setting(options)
+    if options.user_hosts:
+        check_user_data_dir(user_data_dir, options.tdstream)
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `.venv/bin/python -m pytest tests/test_settings.py -v`
+Expected: PASS
+
+Run: `.venv/bin/python -m pytest -q`
+Expected: PASS, no regressions.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add webssh/settings.py webssh/main.py tests/test_settings.py
+git commit -m "feat: add user_hosts and userdatadir configuration options"
+```
+
+---
+
+### Task 4: Host and settings APIs
+
+**Files:**
+- Modify: `webssh/handler.py` — add handlers after `UserKeyHandler` (line 711)
+- Modify: `webssh/main.py:23-60` (`make_handlers`)
+- Test: `tests/test_app.py`
+
+**Interfaces:**
+- Consumes: `webssh.user_data` (Task 2), `get_user_data_dir_setting` (Task 3).
+- Produces:
+  - `UserDataMixin` with `get_auth_username()` and `check_feature_enabled()`
+  - `UserHostsHandler` at `/api/hosts` (GET, PUT)
+  - `UserSettingsHandler` at `/api/settings` (GET, PUT)
+  - `make_handlers` passes `user_hosts_enabled`, `user_data_dir`, and `allowed_hosts` to both.
+
+Routes are registered unconditionally. Gating happens inside the handler so a disabled feature returns 403 rather than 404, which is what the spec requires and what the tests assert.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `tests/test_app.py`:
+
+Follow the `OtherTestBase.get_app` convention already in this file: set the
+`options` attributes the handlers read, then call `make_handlers`. Do not reach
+into `app.default_router` — the router internals differ between Tornado versions.
+
+```python
+class UserDataTestBase(TestAppBase):
+
+    headers = {'Cookie': '_xsrf=yummy',
+               'X-Authentik-Username': 'alice'}
+    user_hosts = True
+
+    def get_app(self):
+        self.data_dir = tempfile.mkdtemp()
+        options.debug = False
+        options.xsrf = True
+        options.policy = 'warning'
+        options.hostfile = ''
+        options.syshostfile = ''
+        options.tdstream = ''
+        options.origin = 'same'
+        options.user_hosts = self.user_hosts
+        options.userdatadir = self.data_dir
+        options.userheader = 'X-Authentik-Username'
+        self.addCleanup(self._restore_options)
+        return make_app(make_handlers(self.io_loop, options),
+                        get_app_settings(options))
+
+    def _restore_options(self):
+        options.user_hosts = False
+        options.userdatadir = ''
+        options.config = ''
+
+
+class TestUserDataApi(UserDataTestBase):
+
+    def put(self, path, payload, headers=None):
+        body = json.dumps(payload)
+        hdrs = dict(headers if headers is not None else self.headers)
+        hdrs['Content-Type'] = 'application/json'
+        hdrs['X-Xsrftoken'] = 'yummy'
+        return self.fetch(path, method='PUT', body=body, headers=hdrs)
+
+    def test_get_hosts_empty(self):
+        response = self.fetch('/api/hosts', headers=self.headers)
+        self.assertEqual(response.code, 200)
+        data = json.loads(to_str(response.body))
+        self.assertEqual(data['user_hosts'], [])
+        self.assertIn('admin_hosts', data)
+
+    def test_put_then_get_hosts(self):
+        response = self.put('/api/hosts', {'hosts': [{'hostname': 'nas.lan',
+                                                      'port': 2222}]})
+        self.assertEqual(response.code, 200)
+        response = self.fetch('/api/hosts', headers=self.headers)
+        data = json.loads(to_str(response.body))
+        self.assertEqual(len(data['user_hosts']), 1)
+        self.assertEqual(data['user_hosts'][0]['port'], 2222)
+
+    def test_put_invalid_host_returns_400_and_preserves_data(self):
+        self.put('/api/hosts', {'hosts': [{'hostname': 'good.lan'}]})
+        response = self.put('/api/hosts',
+                            {'hosts': [{'hostname': 'bad', 'port': 0}]})
+        self.assertEqual(response.code, 400)
+        response = self.fetch('/api/hosts', headers=self.headers)
+        data = json.loads(to_str(response.body))
+        self.assertEqual(data['user_hosts'][0]['hostname'], 'good.lan')
+
+    def test_put_malformed_json_returns_400(self):
+        response = self.fetch(
+            '/api/hosts', method='PUT', body='{not json',
+            headers=dict(self.headers, **{'X-Xsrftoken': 'yummy',
+                                          'Content-Type': 'application/json'}))
+        self.assertEqual(response.code, 400)
+
+    def test_missing_auth_header_returns_401(self):
+        response = self.fetch('/api/hosts', headers={'Cookie': '_xsrf=yummy'})
+        self.assertEqual(response.code, 401)
+
+    def test_invalid_username_returns_400(self):
+        response = self.fetch('/api/hosts', headers={
+            'Cookie': '_xsrf=yummy', 'X-Authentik-Username': '../etc'})
+        self.assertEqual(response.code, 400)
+
+    def test_put_without_xsrf_returns_403(self):
+        response = self.fetch(
+            '/api/hosts', method='PUT', body=json.dumps({'hosts': []}),
+            headers=self.headers)
+        self.assertEqual(response.code, 403)
+
+    def test_settings_round_trip(self):
+        response = self.put('/api/settings', {'settings': {'font_size': 15}})
+        self.assertEqual(response.code, 200)
+        response = self.fetch('/api/settings', headers=self.headers)
+        data = json.loads(to_str(response.body))
+        self.assertEqual(data['settings']['font_size'], 15)
+
+    def test_settings_drops_secrets(self):
+        self.put('/api/settings',
+                 {'settings': {'font_size': 15, 'password': 'hunter2'}})
+        response = self.fetch('/api/settings', headers=self.headers)
+        data = json.loads(to_str(response.body))
+        self.assertNotIn('password', data['settings'])
+
+    def test_users_are_isolated(self):
+        self.put('/api/hosts', {'hosts': [{'hostname': 'alice.lan'}]})
+        response = self.fetch('/api/hosts', headers={
+            'Cookie': '_xsrf=yummy', 'X-Authentik-Username': 'bob'})
+        data = json.loads(to_str(response.body))
+        self.assertEqual(data['user_hosts'], [])
+
+
+class TestUserDataApiDisabled(UserDataTestBase):
+
+    user_hosts = False
+
+    def test_get_hosts_returns_403(self):
+        response = self.fetch('/api/hosts', headers=self.headers)
+        self.assertEqual(response.code, 403)
+
+    def test_get_settings_returns_403(self):
+        response = self.fetch('/api/settings', headers=self.headers)
+        self.assertEqual(response.code, 403)
+```
+
+`tests/test_app.py` currently imports `json` but not `tempfile` or `unittest`.
+Add both to the imports at the top of the file; `unittest` is needed by Task 5.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `.venv/bin/python -m pytest tests/test_app.py::TestUserDataApi -v`
+Expected: FAIL — the routes 404 because they do not exist yet.
+
+- [ ] **Step 3: Write the handlers**
+
+In `webssh/handler.py`, add `from webssh import user_data` alongside the existing `user_keys` import, then add after `UserKeyHandler`:
+
+```python
+class UserDataMixin(object):
+
+    def initialize(self, loop, user_data_dir, user_header,
+                   user_hosts_enabled, allowed_hosts=None, live_config=None):
+        super(UserDataMixin, self).initialize(loop)
+        self.user_data_dir = user_data_dir
+        self.user_header = user_header
+        self.user_hosts_enabled = user_hosts_enabled
+        self.live_config = live_config if live_config is not None else {}
+        self._allowed_hosts = allowed_hosts or []
+
+    @property
+    def allowed_hosts(self):
+        return self.live_config.get('allowed_hosts', self._allowed_hosts) or []
+
+    def check_feature_enabled(self):
+        if not self.user_hosts_enabled or not self.user_data_dir:
+            raise tornado.web.HTTPError(
+                403, 'User host management is not enabled.')
+
+    def get_auth_username(self):
+        username = self.request.headers.get(self.user_header, '')
+        if not username:
+            raise tornado.web.HTTPError(401, 'No authenticated user found.')
+        try:
+            user_keys.sanitize_username(username)
+        except ValueError:
+            raise tornado.web.HTTPError(400, 'Invalid username.')
+        return username
+
+    def get_json_body(self, key, default):
+        try:
+            data = json.loads(self.request.body.decode('utf-8'))
+        except (ValueError, UnicodeDecodeError):
+            raise tornado.web.HTTPError(400, 'Malformed JSON body.')
+        if not isinstance(data, dict):
+            raise tornado.web.HTTPError(400, 'Body must be a JSON object.')
+        return data.get(key, default)
+
+
+class UserHostsHandler(UserDataMixin, MixinHandler,
+                       tornado.web.RequestHandler):
+
+    def get(self):
+        self.check_feature_enabled()
+        username = self.get_auth_username()
+        self.write({
+            'admin_hosts': self.allowed_hosts,
+            'user_hosts': user_data.read_hosts(self.user_data_dir, username),
+        })
+
+    def put(self):
+        self.check_feature_enabled()
+        username = self.get_auth_username()
+        hosts = self.get_json_body('hosts', [])
+        try:
+            stored = user_data.write_hosts(self.user_data_dir, username, hosts)
+        except ValueError as exc:
+            raise tornado.web.HTTPError(400, str(exc))
+        self.write({'user_hosts': stored})
+
+
+class UserSettingsHandler(UserDataMixin, MixinHandler,
+                          tornado.web.RequestHandler):
+
+    def get(self):
+        self.check_feature_enabled()
+        username = self.get_auth_username()
+        self.write({
+            'settings': user_data.read_settings(self.user_data_dir, username),
+        })
+
+    def put(self):
+        self.check_feature_enabled()
+        username = self.get_auth_username()
+        settings = self.get_json_body('settings', {})
+        try:
+            stored = user_data.write_settings(
+                self.user_data_dir, username, settings)
+        except ValueError as exc:
+            raise tornado.web.HTTPError(400, str(exc))
+        self.write({'settings': stored})
+```
+
+`json` is already imported at the top of `handler.py`; confirm with `grep -n '^import json' webssh/handler.py` and add it if missing.
+
+- [ ] **Step 4: Register the routes**
+
+In `webssh/main.py`, import `get_user_data_dir_setting` (already added in Task 3) and extend `make_handlers`. After the `user_header = options.userheader` line:
+
+```python
+    user_data_dir = get_user_data_dir_setting(options)
+    user_hosts_enabled = bool(options.user_hosts and user_data_dir)
+
+    user_data_kwargs = dict(
+        loop=loop,
+        user_data_dir=user_data_dir,
+        user_header=user_header,
+        user_hosts_enabled=user_hosts_enabled,
+        allowed_hosts=allowed_hosts,
+        live_config=live_config
+    )
+```
+
+and extend the `handlers` list:
+
+```python
+    handlers = [
+        (r'/', IndexHandler, index_kwargs),
+        (r'/ws', WsockHandler, dict(loop=loop)),
+        (r'/api/hosts', UserHostsHandler, user_data_kwargs),
+        (r'/api/settings', UserSettingsHandler, user_data_kwargs),
+    ]
+```
+
+Add `UserHostsHandler` and `UserSettingsHandler` to the `from webssh.handler import (...)` list at lines 11-13.
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `.venv/bin/python -m pytest tests/test_app.py::TestUserDataApi tests/test_app.py::TestUserDataApiDisabled -v`
+Expected: PASS
+
+Run: `.venv/bin/python -m pytest -q`
+Expected: PASS, no regressions.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add webssh/handler.py webssh/main.py tests/test_app.py
+git commit -m "feat: add /api/hosts and /api/settings endpoints"
+```
+
+---
+
+### Task 5: Merge user hosts at connect time
+
+This is the security-critical task. Two invariants must hold: an administrator entry always wins a `hostname:port` collision, and with the feature disabled a user-supplied host is still rejected by the allowlist.
+
+**Files:**
+- Modify: `webssh/handler.py:344-359` (`IndexHandler.initialize`), `:423-440` (`check_allowed_hosts`, `load_configured_host_key`), `:599-625` (`get`)
+- Modify: `webssh/main.py` — pass the two new kwargs into `index_kwargs`
+- Test: `tests/test_app.py`
+
+**Interfaces:**
+- Consumes: `user_data.read_hosts` (Task 2), `user_hosts_enabled` / `user_data_dir` wiring (Tasks 3 and 4).
+- Produces: `IndexHandler.get_user_hosts()` → `list[dict]` and `IndexHandler.get_effective_hosts()` → `list[dict]`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `tests/test_app.py`:
+
+```python
+class TestEffectiveHosts(unittest.TestCase):
+    """Unit-level checks of the admin/user host merge."""
+
+    def _handler(self, admin_hosts, user_hosts):
+        from webssh.handler import IndexHandler
+        h = IndexHandler.__new__(IndexHandler)
+        h.allowed_hosts = admin_hosts
+        h._user_hosts = user_hosts
+        h.get_user_hosts = lambda: h._user_hosts
+        return h
+
+    def test_admin_host_wins_collision(self):
+        from webssh.handler import IndexHandler
+        admin = [{'name': 'prod', 'hostname': '10.0.1.5', 'port': 22,
+                  'host_keys': ['ssh-ed25519 AAAAadmin']}]
+        user = [{'name': 'mine', 'hostname': '10.0.1.5', 'port': 22,
+                 'host_keys': ['ssh-ed25519 AAAAuser']}]
+        h = self._handler(admin, user)
+        effective = IndexHandler.get_effective_hosts(h)
+        self.assertEqual(len(effective), 1)
+        self.assertEqual(effective[0]['host_keys'], ['ssh-ed25519 AAAAadmin'])
+
+    def test_different_port_is_not_a_collision(self):
+        from webssh.handler import IndexHandler
+        admin = [{'name': 'prod', 'hostname': '10.0.1.5', 'port': 22,
+                  'host_keys': []}]
+        user = [{'name': 'mine', 'hostname': '10.0.1.5', 'port': 2222,
+                 'host_keys': []}]
+        h = self._handler(admin, user)
+        self.assertEqual(len(IndexHandler.get_effective_hosts(h)), 2)
+
+    def test_user_hosts_appended(self):
+        from webssh.handler import IndexHandler
+        h = self._handler([{'name': 'a', 'hostname': 'a.com', 'port': 22,
+                            'host_keys': []}],
+                          [{'name': 'b', 'hostname': 'b.com', 'port': 22,
+                            'host_keys': []}])
+        names = [x['name'] for x in IndexHandler.get_effective_hosts(h)]
+        self.assertEqual(names, ['a', 'b'])
+```
+
+And an end-to-end pair asserting the allowlist gate. The administrator allowlist
+is supplied the same way production does it — through a config file — because
+`make_handlers` calls `get_allowed_hosts_setting(options)`, which reads
+`options.config`:
+
+```python
+class TestConnectWithUserHosts(UserDataTestBase):
+
+    admin_hostname = '10.9.9.9'
+
+    def setUp(self):
+        import yaml
+        fd, self.config_path = tempfile.mkstemp(suffix='.yaml')
+        with os.fdopen(fd, 'w') as f:
+            yaml.safe_dump({'hosts': [
+                {'name': 'other', 'hostname': self.admin_hostname,
+                 'port': 22}]}, f)
+        options.config = self.config_path
+        super(TestConnectWithUserHosts, self).setUp()
+        from webssh.user_data import write_hosts
+        write_hosts(self.data_dir, 'alice',
+                    [{'hostname': '127.0.0.1', 'port': 7000}])
+
+    def tearDown(self):
+        os.unlink(self.config_path)
+        super(TestConnectWithUserHosts, self).tearDown()
+
+    def test_user_host_passes_the_allowlist(self):
+        body = ('hostname=127.0.0.1&port=7000&username=robey&password=foo'
+                '&_xsrf=yummy')
+        response = self.fetch('/', method='POST', body=body,
+                              headers=self.headers)
+        # The allowlist must not reject it. The SSH connection itself will
+        # fail (no server on that port), which is fine and not what we assert.
+        self.assertNotIn(b'is not allowed', response.body)
+
+    def test_host_in_neither_list_is_rejected(self):
+        body = ('hostname=127.0.0.2&port=7000&username=robey&password=foo'
+                '&_xsrf=yummy')
+        response = self.fetch('/', method='POST', body=body,
+                              headers=self.headers)
+        self.assertIn(b'is not allowed', response.body)
+
+
+class TestConnectWithUserHostsDisabled(TestConnectWithUserHosts):
+
+    user_hosts = False
+
+    def test_user_host_is_rejected_when_feature_disabled(self):
+        body = ('hostname=127.0.0.1&port=7000&username=robey&password=foo'
+                '&_xsrf=yummy')
+        response = self.fetch('/', method='POST', body=body,
+                              headers=self.headers)
+        self.assertIn(b'is not allowed', response.body)
+
+    def test_user_host_passes_the_allowlist(self):
+        pass  # inverted above; the enabled-case assertion does not apply
+```
+
+`tests/test_app.py` imports `json` but not `os`, so add `import os` too (Task 4
+already added `tempfile` and `unittest`).
+
+The `setUp` ordering matters: `options.config` must be set before
+`super().setUp()`, because `AsyncHTTPTestCase.setUp` is what calls `get_app`.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `.venv/bin/python -m pytest tests/test_app.py::TestEffectiveHosts -v`
+Expected: FAIL with `AttributeError: type object 'IndexHandler' has no attribute 'get_effective_hosts'`
+
+- [ ] **Step 3: Implement the merge**
+
+In `IndexHandler.initialize`, extend the signature and body:
+
+```python
+    def initialize(self, loop, policy, host_keys_settings, allowed_hosts=None,
+                   user_key_dir='', user_header='X-Authentik-Username',
+                   user_data_dir='', user_hosts_enabled=False,
+                   live_config=None):
+```
+
+and after the existing `self.user_header = user_header` line:
+
+```python
+        self.user_data_dir = user_data_dir
+        self.user_hosts_enabled = user_hosts_enabled
+```
+
+Add the two new methods just above `check_allowed_hosts`:
+
+```python
+    def get_user_hosts(self):
+        if not self.user_hosts_enabled or not self.user_data_dir:
+            return []
+        username = self.request.headers.get(self.user_header, '')
+        if not username:
+            return []
+        try:
+            return user_data.read_hosts(self.user_data_dir, username)
+        except ValueError:
+            return []
+
+    def get_effective_hosts(self):
+        admin = self.allowed_hosts
+        seen = set((h['hostname'], h['port']) for h in admin)
+        merged = list(admin)
+        for host in self.get_user_hosts():
+            if (host['hostname'], host['port']) not in seen:
+                merged.append(host)
+        return merged
+```
+
+Replace `check_allowed_hosts` and `load_configured_host_key`:
+
+```python
+    def check_allowed_hosts(self, hostname, port):
+        if not self.allowed_hosts:
+            return
+        for host in self.get_effective_hosts():
+            if host['hostname'] == hostname and host['port'] == port:
+                return
+        raise tornado.web.HTTPError(
+            403, 'Connection to {}:{} is not allowed.'.format(hostname, port)
+        )
+
+    def load_configured_host_key(self, hostname, port):
+        for host in self.get_effective_hosts():
+            if host['hostname'] == hostname and host['port'] == port:
+                for key_str in host.get('host_keys', []):
+                    self._add_host_key(hostname, port, key_str)
+                return
+```
+
+Two subtleties, both deliberate:
+
+- `check_allowed_hosts` keeps its `if not self.allowed_hosts: return` guard. When no administrator allowlist is configured the hostname field is free text, and adding personal hosts must not suddenly restrict the user to only those hosts.
+- `load_configured_host_key` *drops* its equivalent guard. A personal host's key pin must load even when no administrator allowlist exists; with an empty effective list the loop is a harmless no-op.
+
+- [ ] **Step 4: Pass the new kwargs**
+
+In `webssh/main.py`, add to `index_kwargs`:
+
+```python
+        user_data_dir=user_data_dir,
+        user_hosts_enabled=user_hosts_enabled,
+```
+
+- [ ] **Step 5: Expose hosts to the template**
+
+In `IndexHandler.get`, before the `self.render(...)` call, add:
+
+```python
+        user_hosts = self.get_user_hosts()
+        user_settings = {}
+        if self.user_hosts_enabled and auth_username:
+            try:
+                user_settings = user_data.read_settings(
+                    self.user_data_dir, auth_username)
+            except ValueError:
+                user_settings = {}
+```
+
+and extend the `render` call with:
+
+```python
+                    user_hosts_enabled=self.user_hosts_enabled,
+                    user_hosts=user_hosts,
+                    user_settings=user_settings,
+```
+
+Note: `self.allowed_hosts` is still what the template's existing host `<select>` iterates. Task 7 changes that to the merged list.
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `.venv/bin/python -m pytest tests/test_app.py -v`
+Expected: PASS
+
+Run: `.venv/bin/python -m pytest -q`
+Expected: PASS, no regressions. Pay particular attention to any existing allowed-hosts test — those assert the disabled-feature behavior that must not change.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add webssh/handler.py webssh/main.py tests/test_app.py
+git commit -m "feat: merge user hosts with admin allowlist at connect time"
+```
+
+---
+
+### Task 6: Settings pane endpoint and template
+
+**Files:**
+- Create: `webssh/templates/settings.html`
+- Modify: `webssh/handler.py` — add `SettingsPaneHandler` after `UserSettingsHandler`
+- Modify: `webssh/main.py` — register `/settings-pane`
+- Modify: `webssh/static/css/main.css` — append settings styles
+- Test: `tests/test_app.py`
+
+**Interfaces:**
+- Consumes: `UserDataMixin` (Task 4).
+- Produces: `GET /settings-pane` → an HTML fragment (no `<html>`/`<body>`), 404 when the feature is disabled. The fragment's root element is `<div class="settings-pane">`, and it contains `#settings-hosts`, `#settings-terminal`, and `#settings-connection` sections plus a `#settings-save` button. Task 7 depends on these IDs.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/test_app.py`, inside `TestUserDataApi`:
+
+```python
+    def test_settings_pane_returns_fragment(self):
+        response = self.fetch('/settings-pane', headers=self.headers)
+        self.assertEqual(response.code, 200)
+        self.assertIn(b'settings-pane', response.body)
+        self.assertNotIn(b'<html', response.body)
+```
+
+and inside `TestUserDataApiDisabled`:
+
+```python
+    def test_settings_pane_returns_404(self):
+        response = self.fetch('/settings-pane', headers=self.headers)
+        self.assertEqual(response.code, 404)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `.venv/bin/python -m pytest tests/test_app.py::TestUserDataApi::test_settings_pane_returns_fragment -v`
+Expected: FAIL with a 404.
+
+- [ ] **Step 3: Write the handler**
+
+In `webssh/handler.py`, after `UserSettingsHandler`:
+
+```python
+class SettingsPaneHandler(UserDataMixin, MixinHandler,
+                          tornado.web.RequestHandler):
+
+    def get(self):
+        if not self.user_hosts_enabled or not self.user_data_dir:
+            raise tornado.web.HTTPError(404)
+        username = self.get_auth_username()
+        self.render('settings.html',
+                    auth_username=username,
+                    admin_hosts=self.allowed_hosts)
+```
+
+Register in `webssh/main.py` alongside the API routes:
+
+```python
+        (r'/settings-pane', SettingsPaneHandler, user_data_kwargs),
+```
+
+and add `SettingsPaneHandler` to the handler import list.
+
+- [ ] **Step 4: Write the template**
+
+Create `webssh/templates/settings.html`. It renders only the static shell; host rows and current values are filled in by JavaScript in Task 7 from `/api/hosts` and the in-page `prefs` object.
+
+```html
+<div class="settings-pane">
+  <div class="settings-header">
+    <span class="settings-title">Settings</span>
+    <span class="settings-user">{{ auth_username }}</span>
+  </div>
+
+  <div class="settings-tabs" role="tablist">
+    <button type="button" class="settings-tab active" data-section="hosts" role="tab">Hosts</button>
+    <button type="button" class="settings-tab" data-section="terminal" role="tab">Terminal</button>
+    <button type="button" class="settings-tab" data-section="connection" role="tab">Connection</button>
+  </div>
+
+  <div class="settings-body">
+    <section id="settings-hosts" class="settings-section active">
+      {% if admin_hosts %}
+      <div class="settings-subhead">Administrator hosts (read-only)</div>
+      <table class="settings-table">
+        <tbody>
+          {% for host in admin_hosts %}
+          <tr class="admin-host">
+            <td>{{ host['name'] }}</td>
+            <td>{{ host['hostname'] }}</td>
+            <td>{{ host['port'] }}</td>
+            <td><span class="host-badge">admin</span></td>
+          </tr>
+          {% end %}
+        </tbody>
+      </table>
+      {% end %}
+
+      <div class="settings-subhead">Your hosts</div>
+      <table class="settings-table">
+        <tbody id="user-host-rows"></tbody>
+      </table>
+      <button type="button" class="btn-generate" id="add-host-btn">+ Add host</button>
+    </section>
+
+    <section id="settings-terminal" class="settings-section">
+      <div class="field-row">
+        <div class="field-group">
+          <span class="field-label">Font Size</span>
+          <input class="field-input" type="number" id="set-font-size" min="6" max="40" placeholder="14">
+        </div>
+        <div class="field-group">
+          <span class="field-label">Background</span>
+          <input class="field-input" type="text" id="set-background" placeholder="black">
+        </div>
+      </div>
+      <div class="field-row">
+        <div class="field-group">
+          <span class="field-label">Foreground</span>
+          <input class="field-input" type="text" id="set-foreground" placeholder="white">
+        </div>
+        <div class="field-group">
+          <span class="field-label">Cursor</span>
+          <input class="field-input" type="text" id="set-cursor" placeholder="white">
+        </div>
+      </div>
+      <div class="field-row single">
+        <label class="settings-checkbox">
+          <input type="checkbox" id="set-cursor-blink"> Cursor blink
+        </label>
+      </div>
+    </section>
+
+    <section id="settings-connection" class="settings-section">
+      <div class="field-row">
+        <div class="field-group">
+          <span class="field-label">Encoding</span>
+          <input class="field-input" type="text" id="set-encoding" placeholder="utf-8">
+        </div>
+        <div class="field-group">
+          <span class="field-label">Terminal Type</span>
+          <input class="field-input" type="text" id="set-term" placeholder="xterm-256color">
+        </div>
+      </div>
+      <div class="field-row single">
+        <div class="field-group">
+          <span class="field-label">Preferred Key Source</span>
+          <select class="field-input" id="set-key-source">
+            <option value="upload">Upload Key</option>
+            <option value="stored">Stored Key</option>
+          </select>
+        </div>
+      </div>
+    </section>
+  </div>
+
+  <div class="settings-footer">
+    <span class="settings-status" id="settings-status"></span>
+    <button type="button" class="btn-connect btn-primary" id="settings-save">Save</button>
+  </div>
+</div>
+
+<template id="host-row-template">
+  <tr class="user-host">
+    <td><input class="field-input host-name" type="text" placeholder="Name"></td>
+    <td><input class="field-input host-hostname" type="text" placeholder="hostname" required></td>
+    <td><input class="field-input host-port" type="number" min="1" max="65535" placeholder="22"></td>
+    <td><input class="field-input host-username" type="text" placeholder="login user"></td>
+    <td><input class="field-input host-command" type="text" placeholder="default command"></td>
+    <td><textarea class="field-input host-keys" rows="2" placeholder="ssh-ed25519 AAAA... (one per line)"></textarea></td>
+    <td><button type="button" class="btn-reset btn-danger host-delete" title="Delete host">&times;</button></td>
+  </tr>
+</template>
+```
+
+- [ ] **Step 5: Add the styles**
+
+Append to `webssh/static/css/main.css`. Reuse the existing color variables rather than inventing new ones — check the top of the file for the custom properties already defined and substitute the real names if these differ:
+
+```css
+.settings-pane {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow: hidden;
+  color: inherit;
+}
+
+.settings-header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  padding: 12px 16px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.12);
+}
+
+.settings-title { font-weight: 600; letter-spacing: 0.04em; }
+.settings-user { opacity: 0.7; font-size: 0.85em; }
+
+.settings-tabs { display: flex; gap: 4px; padding: 8px 16px 0; }
+
+.settings-tab {
+  background: none;
+  border: none;
+  border-bottom: 2px solid transparent;
+  padding: 6px 12px;
+  color: inherit;
+  opacity: 0.6;
+  cursor: pointer;
+}
+
+.settings-tab.active { opacity: 1; border-bottom-color: currentColor; }
+
+.settings-body { flex: 1; overflow-y: auto; padding: 16px; }
+.settings-section { display: none; }
+.settings-section.active { display: block; }
+
+.settings-subhead {
+  text-transform: uppercase;
+  font-size: 0.75em;
+  letter-spacing: 0.08em;
+  opacity: 0.6;
+  margin: 16px 0 8px;
+}
+
+.settings-table { width: 100%; border-collapse: collapse; }
+.settings-table td { padding: 4px; vertical-align: top; }
+.settings-table tr.admin-host td { opacity: 0.55; padding: 6px 4px; }
+
+.host-badge {
+  font-size: 0.7em;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  border: 1px solid currentColor;
+  border-radius: 3px;
+  padding: 1px 5px;
+  opacity: 0.8;
+}
+
+.settings-checkbox { display: flex; align-items: center; gap: 8px; }
+
+.settings-footer {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 12px;
+  padding: 12px 16px;
+  border-top: 1px solid rgba(255, 255, 255, 0.12);
+}
+
+.settings-status { font-size: 0.85em; opacity: 0.75; }
+.settings-status.error { color: #ff6b6b; opacity: 1; }
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `.venv/bin/python -m pytest tests/test_app.py -v`
+Expected: PASS
+
+Run: `.venv/bin/python -m pytest -q`
+Expected: PASS, no regressions.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add webssh/handler.py webssh/main.py webssh/templates/settings.html webssh/static/css/main.css tests/test_app.py
+git commit -m "feat: add /settings-pane fragment endpoint and template"
+```
+
+---
+
+### Task 7: Settings tab in the client
+
+**Files:**
+- Modify: `webssh/static/js/main.js:69-147` (`createTab`), `:149-193` (`activateTab`), `:195-243` (`closeTab`)
+- Modify: `webssh/templates/index.html:26-29` (tab bar), `:51-59` (host select), `:178-182` (bootstrap globals)
+
+**Interfaces:**
+- Consumes: `GET /settings-pane`, `GET/PUT /api/hosts` (Tasks 4 and 6).
+- Produces:
+  - `tabManager.createTab(kind)` where `kind` is `'terminal'` (default) or `'settings'`
+  - `tabManager.openSettings()` — focuses the existing settings tab or creates one
+  - `refresh_host_list()` — refetches `/api/hosts` and rebuilds the `#hostname` select
+
+- [ ] **Step 1: Add the gear control and globals to index.html**
+
+In the tab bar block, add a gear button next to the new-tab button:
+
+```html
+    <div id="tab-bar">
+      <div id="tab-list"></div>
+      <button id="new-tab-btn" type="button" title="New connection" aria-label="Open new connection tab">+</button>
+      {% if user_hosts_enabled %}
+      <button id="settings-btn" type="button" title="Settings" aria-label="Open settings">&#9881;</button>
+      {% end %}
+    </div>
+```
+
+Change the host `<select>` block so it renders the merged list. Replace the `{% if allowed_hosts %}` condition and loop with:
+
+```html
+                {% if allowed_hosts or user_hosts %}
+                <select class="field-input" id="hostname" name="hostname" required>
+                  {% for host in allowed_hosts %}
+                  <option value="{{ host['hostname'] }}" data-port="{{ host['port'] }}">{{ host['name'] }}</option>
+                  {% end %}
+                  {% for host in user_hosts %}
+                  <option value="{{ host['hostname'] }}" data-port="{{ host['port'] }}" data-username="{{ host['username'] }}" data-command="{{ host['default_command'] }}">{{ host['name'] }}</option>
+                  {% end %}
+                </select>
+                {% else %}
+```
+
+The port field's `readonly` attribute at line 84 must follow the same condition — change `{% if allowed_hosts %}readonly{% end %}` to `{% if allowed_hosts or user_hosts %}readonly{% end %}`.
+
+Add to the globals script block:
+
+```html
+      var allowed_hosts_configured = {% if allowed_hosts or user_hosts %}true{% else %}false{% end %};
+      var user_hosts_enabled = {% if user_hosts_enabled %}true{% else %}false{% end %};
+      var user_settings = {% raw json_encode(user_settings) %};
+```
+
+- [ ] **Step 2: Teach tabManager about tab kinds**
+
+In `main.js`, change the `createTab` signature and the tab object it builds:
+
+```javascript
+    createTab: function(kind) {
+      kind = kind || 'terminal';
+      var tabId = ++this.tabCounter;
+      var container = document.createElement('div');
+      container.className = 'terminal-pane';
+      container.id = 'terminal-pane-' + tabId;
+```
+
+In the same function, set the initial label from the kind:
+
+```javascript
+      var label = document.createElement('span');
+      label.className = 'tab-label';
+      label.textContent = (kind === 'settings') ? 'Settings' : 'New Connection';
+```
+
+and add `kind` to the tab object literal, alongside `id` and `label`:
+
+```javascript
+      var tab = {
+        id: tabId,
+        kind: kind,
+        label: (kind === 'settings') ? 'Settings' : 'New Connection',
+```
+
+- [ ] **Step 3: Branch activateTab on kind**
+
+Replace the `if (tab.state === CONNECTED && tab.term) { ... } else { ... }` block in `activateTab` with:
+
+```javascript
+      if (tab.kind === 'settings') {
+        form_container.hide();
+      } else if (tab.state === CONNECTED && tab.term) {
+        form_container.hide();
+        // Fit after a brief delay so layout settles, then focus
+        setTimeout(function() {
+          if (tab.fitAddon) {
+            tab.fitAddon.fit();
+          }
+          if (tab.term) {
+            setTimeout(function() { tab.term.focus(); }, 50);
+          }
+        }, 10);
+      } else {
+        form_container.show();
+      }
+```
+
+and the title block below it:
+
+```javascript
+      if (tab.kind === 'settings') {
+        title_element.text = 'Settings';
+      } else if (tab.state === CONNECTED && tab.title) {
+        title_element.text = tab.title;
+      } else {
+        title_element.text = default_title;
+      }
+```
+
+`bindWssh(tab)` is called unconditionally at the end of `activateTab`. Verify it tolerates `tab.term === null`; if it dereferences `tab.term`, guard the call with `if (tab.kind !== 'settings') { this.bindWssh(tab); }`.
+
+- [ ] **Step 4: Make the last-closed tab a terminal tab**
+
+In `closeTab`, the fallback at the end currently reads `this.createTab();`. It already defaults to a terminal tab now that `kind` defaults to `'terminal'`, but make it explicit:
+
+```javascript
+        } else {
+          // No tabs left, create new one
+          this.createTab('terminal');
+        }
+```
+
+- [ ] **Step 5: Add openSettings and wire the gear button**
+
+Add to `tabManager`, after `getActiveTab`:
+
+```javascript
+    openSettings: function() {
+      var ids = this.getTabIds();
+      for (var i = 0; i < ids.length; i++) {
+        if (this.tabs[ids[i]].kind === 'settings') {
+          this.activateTab(ids[i]);
+          return;
+        }
+      }
+      var tab = this.createTab('settings');
+      var pane = $(tab.containerEl);
+      pane.html('<div class="settings-loading">Loading settings...</div>');
+      $.get('/settings-pane')
+        .done(function(html) {
+          pane.html(html);
+          init_settings_pane(pane);
+        })
+        .fail(function() {
+          pane.html('<div class="settings-loading">Failed to load settings.</div>');
+        });
+      return tab;
+    },
+```
+
+Wire the button where the other DOM handlers are bound, near the `#new-tab-btn` handler:
+
+```javascript
+  $('#settings-btn').on('click', function() {
+    tabManager.openSettings();
+  });
+```
+
+- [ ] **Step 6: Implement the settings pane behavior**
+
+Add these functions near the other utility functions:
+
+```javascript
+  function settings_status(pane, message, is_error) {
+    var el = pane.find('#settings-status');
+    el.text(message || '');
+    el.toggleClass('error', !!is_error);
+  }
+
+
+  function add_host_row(pane, host) {
+    host = host || {};
+    var tpl = pane.find('#host-row-template')[0];
+    var row = $(document.importNode(tpl.content, true));
+    row.find('.host-name').val(host.name || '');
+    row.find('.host-hostname').val(host.hostname || '');
+    row.find('.host-port').val(host.port || '');
+    row.find('.host-username').val(host.username || '');
+    row.find('.host-command').val(host.default_command || '');
+    row.find('.host-keys').val((host.host_keys || []).join('\n'));
+    pane.find('#user-host-rows').append(row);
+  }
+
+
+  function collect_host_rows(pane) {
+    var hosts = [];
+    pane.find('#user-host-rows tr.user-host').each(function() {
+      var row = $(this);
+      var hostname = row.find('.host-hostname').val().trim();
+      if (!hostname) return;
+      var keys = row.find('.host-keys').val().split('\n');
+      var cleaned = [];
+      for (var i = 0; i < keys.length; i++) {
+        var k = keys[i].trim();
+        if (k) cleaned.push(k);
+      }
+      var port = window.parseInt(row.find('.host-port').val(), 10);
+      hosts.push({
+        name: row.find('.host-name').val().trim() || hostname,
+        hostname: hostname,
+        port: port > 0 ? port : 22,
+        host_key: cleaned,
+        username: row.find('.host-username').val().trim(),
+        default_command: row.find('.host-command').val().trim()
+      });
+    });
+    return hosts;
+  }
+
+
+  function collect_settings(pane) {
+    var settings = {};
+    var size = window.parseInt(pane.find('#set-font-size').val(), 10);
+    if (size > 0) settings.font_size = size;
+    var pairs = {
+      background: '#set-background', foreground: '#set-foreground',
+      cursor: '#set-cursor', encoding: '#set-encoding', term: '#set-term'
+    };
+    for (var key in pairs) {
+      var value = pane.find(pairs[key]).val().trim();
+      if (value) settings[key] = value;
+    }
+    settings.cursor_blink = pane.find('#set-cursor-blink').is(':checked');
+    settings.key_source = pane.find('#set-key-source').val();
+    return settings;
+  }
+
+
+  function init_settings_pane(pane) {
+    pane.find('.settings-tab').on('click', function() {
+      var section = $(this).data('section');
+      pane.find('.settings-tab').removeClass('active');
+      $(this).addClass('active');
+      pane.find('.settings-section').removeClass('active');
+      pane.find('#settings-' + section).addClass('active');
+    });
+
+    pane.find('#add-host-btn').on('click', function() {
+      add_host_row(pane, {});
+    });
+
+    pane.on('click', '.host-delete', function() {
+      $(this).closest('tr').remove();
+    });
+
+    pane.find('#set-font-size').val(user_settings.font_size || '');
+    pane.find('#set-background').val(user_settings.background || '');
+    pane.find('#set-foreground').val(user_settings.foreground || '');
+    pane.find('#set-cursor').val(user_settings.cursor || '');
+    pane.find('#set-encoding').val(user_settings.encoding || '');
+    pane.find('#set-term').val(user_settings.term || '');
+    pane.find('#set-cursor-blink').prop('checked',
+                                        user_settings.cursor_blink !== false);
+    if (user_settings.key_source) {
+      pane.find('#set-key-source').val(user_settings.key_source);
+    }
+
+    $.get('/api/hosts').done(function(data) {
+      var hosts = data.user_hosts || [];
+      for (var i = 0; i < hosts.length; i++) {
+        add_host_row(pane, hosts[i]);
+      }
+    });
+
+    pane.find('#settings-save').on('click', function() {
+      settings_status(pane, 'Saving...');
+      var hosts = collect_host_rows(pane);
+      var settings = collect_settings(pane);
+      $.ajax({
+        url: '/api/hosts', type: 'PUT', contentType: 'application/json',
+        headers: {'X-Xsrftoken': get_xsrf_token()},
+        data: JSON.stringify({hosts: hosts})
+      }).done(function() {
+        return $.ajax({
+          url: '/api/settings', type: 'PUT', contentType: 'application/json',
+          headers: {'X-Xsrftoken': get_xsrf_token()},
+          data: JSON.stringify({settings: settings})
+        }).done(function(data) {
+          user_settings = data.settings || {};
+          settings_status(pane, 'Saved');
+          refresh_host_list();
+        }).fail(function(xhr) {
+          settings_status(pane, save_error_text(xhr), true);
+        });
+      }).fail(function(xhr) {
+        settings_status(pane, save_error_text(xhr), true);
+      });
+    });
+  }
+
+
+  function save_error_text(xhr) {
+    if (xhr && xhr.status === 400) {
+      return 'Rejected: check hostnames, ports, and host keys.';
+    }
+    return 'Save failed.';
+  }
+
+
+  function get_xsrf_token() {
+    var match = document.cookie.match(/\b_xsrf=([^;]+)/);
+    return match ? decodeURIComponent(match[1]) : '';
+  }
+
+
+  function refresh_host_list() {
+    if (!user_hosts_enabled) return;
+    $.get('/api/hosts').done(function(data) {
+      var select = $('#hostname');
+      if (!select.is('select')) return;
+      var current = select.val();
+      select.empty();
+      var groups = [data.admin_hosts || [], data.user_hosts || []];
+      for (var g = 0; g < groups.length; g++) {
+        for (var i = 0; i < groups[g].length; i++) {
+          var host = groups[g][i];
+          var option = $('<option>')
+            .attr('value', host.hostname)
+            .attr('data-port', host.port)
+            .text(host.name);
+          if (g === 1) {
+            option.attr('data-username', host.username || '');
+            option.attr('data-command', host.default_command || '');
+          }
+          select.append(option);
+        }
+      }
+      if (current) select.val(current);
+      select.trigger('change');
+    });
+  }
+```
+
+- [ ] **Step 7: Prefill username and command from the selected host**
+
+Find the existing `#hostname` change handler (search for `data-port`) and extend it so a user host also prefills the login username and default command:
+
+```javascript
+    var option = $('#hostname option:selected');
+    var host_username = option.attr('data-username');
+    var host_command = option.attr('data-command');
+    if (host_username) $('#username').val(host_username);
+    if (host_command !== undefined) $('#default-command').val(host_command);
+```
+
+Place this after the existing port-setting logic so it does not disturb it.
+
+- [ ] **Step 8: Manual verification**
+
+Start the server with the feature on:
+
+```bash
+mkdir -p /tmp/webssh-data
+.venv/bin/python run.py --port=8889 --user_hosts=true \
+  --userdatadir=/tmp/webssh-data --userheader=X-Test-User --debug
+```
+
+The `userheader` cannot be sent by a browser directly, so verify the APIs with curl and the UI with a browser extension that injects the header, or temporarily hardcode a username for testing. Confirm each of these:
+
+- [ ] The gear button appears in the tab bar.
+- [ ] Clicking it opens a "Settings" tab; the connect form is hidden while it is active.
+- [ ] Clicking the gear again focuses that same tab rather than opening a second one.
+- [ ] Adding a host, saving, and switching to a terminal tab shows the new host in the hostname dropdown without a page reload.
+- [ ] Connecting a terminal, then opening settings, then returning to the terminal tab leaves the session alive and scrolled where it was.
+- [ ] Closing the last remaining tab yields a terminal tab, not a settings tab.
+- [ ] Saving an invalid host (port `0`) shows the inline error and does not clear the form.
+
+- [ ] **Step 9: Run the suite and commit**
+
+Run: `.venv/bin/python -m pytest -q`
+Expected: PASS, no regressions.
+
+```bash
+git add webssh/static/js/main.js webssh/templates/index.html
+git commit -m "feat: add in-app settings tab with host editor"
+```
+
+---
+
+### Task 8: Roaming preferences
+
+**Files:**
+- Modify: `webssh/static/js/main.js:364-420` (`store_items`, `store_default_command`, `restore_default_command`, `restore_items`), plus the terminal construction block at `:703-720`
+
+**Interfaces:**
+- Consumes: `user_settings` global (Task 5 render, Task 7 template), `/api/settings` (Task 4), `refresh_host_list` and `get_xsrf_token` (Task 7).
+- Produces: `prefs.get(name)`, `prefs.set(name, value)`, `prefs.flush()`.
+
+- [ ] **Step 1: Add the prefs object**
+
+Add near the other utility functions in `main.js`:
+
+```javascript
+  var prefs = {
+    pending: null,
+    timer: null,
+
+    get: function(name) {
+      if (user_hosts_enabled && user_settings[name] !== undefined) {
+        return user_settings[name];
+      }
+      return window.localStorage.getItem(name);
+    },
+
+    set: function(name, value) {
+      window.localStorage.setItem(name, value);
+      if (!user_hosts_enabled) return;
+      user_settings[name] = value;
+      this.schedule();
+    },
+
+    schedule: function() {
+      var self = this;
+      if (this.timer) window.clearTimeout(this.timer);
+      this.timer = window.setTimeout(function() { self.flush(); }, 1000);
+    },
+
+    flush: function() {
+      if (!user_hosts_enabled) return;
+      this.timer = null;
+      $.ajax({
+        url: '/api/settings', type: 'PUT', contentType: 'application/json',
+        headers: {'X-Xsrftoken': get_xsrf_token()},
+        data: JSON.stringify({settings: user_settings})
+      });
+    }
+  };
+```
+
+Because `validate_settings` whitelists keys server-side, a stray `credential` or `totp` reaching `user_settings` would be dropped rather than stored. Do not rely on that alone — keep the client from putting them there in the first place, per Step 2.
+
+- [ ] **Step 2: Route last-used values through prefs**
+
+Replace `store_items` and `restore_items` so they persist only the three roaming fields and never the secrets:
+
+```javascript
+  var ROAMING_FIELDS = {
+    hostname: 'last_hostname',
+    username: 'last_username',
+    port: 'last_port'
+  };
+
+
+  function store_items(names, data) {
+    var i, name, value;
+
+    for (i = 0; i < names.length; i++) {
+      name = names[i];
+      value = data.get(name);
+      if (value) {
+        window.localStorage.setItem(name, value);
+        if (ROAMING_FIELDS[name]) {
+          var stored = (name === 'port') ? window.parseInt(value, 10) : value;
+          if (name !== 'port' || stored > 0) {
+            user_settings[ROAMING_FIELDS[name]] = stored;
+          }
+        }
+      }
+    }
+    prefs.schedule();
+  }
+
+
+  function restore_items(names) {
+    var i, name, value;
+
+    for (i = 0; i < names.length; i++) {
+      name = names[i];
+      value = null;
+      if (user_hosts_enabled && ROAMING_FIELDS[name]) {
+        var roamed = user_settings[ROAMING_FIELDS[name]];
+        if (roamed !== undefined && roamed !== null && roamed !== '') {
+          value = String(roamed);
+        }
+      }
+      if (value === null) {
+        value = window.localStorage.getItem(name);
+      }
+      if (value) {
+        var el = $('#' + name);
+        el.val(value);
+        if (name === 'hostname' && el.is('select')) {
+          el.trigger('change');
+        }
+      }
+    }
+  }
+```
+
+`form_keys` includes `credential` and `totp`, and `ROAMING_FIELDS` deliberately omits both, so neither is ever added to `user_settings`. The pre-existing `localStorage` behavior for those fields is unchanged.
+
+- [ ] **Step 3: Move default commands onto host records**
+
+Replace `store_default_command` and `restore_default_command`:
+
+```javascript
+  function find_user_host(hostname, port) {
+    var match = null;
+    $('#hostname option').each(function() {
+      var option = $(this);
+      // Only user hosts carry data-command; admin hosts never do.
+      if (option.attr('data-command') === undefined) return;
+      if (option.attr('value') !== hostname) return;
+      if (String(option.attr('data-port')) !== String(port || 22)) return;
+      match = option;
+      return false;
+    });
+    return match;
+  }
+
+
+  function store_default_command(data) {
+    var key = get_host_key(data);
+    if (!key) return;
+    var command = $('#default-command').val().trim();
+    if (command) {
+      window.localStorage.setItem(key, command);
+    } else {
+      window.localStorage.removeItem(key);
+    }
+    // Server-side hosts own their own default_command, edited in Settings.
+  }
+
+
+  function restore_default_command(hostname, port) {
+    if (!hostname) return;
+    var option = find_user_host(hostname, port);
+    if (option) {
+      $('#default-command').val(option.attr('data-command') || '');
+      return;
+    }
+    var key = get_host_key({hostname: hostname, port: port});
+    if (!key) return;
+    var command = window.localStorage.getItem(key);
+    $('#default-command').val(command || '');
+  }
+```
+
+A saved host's `default_command` is authoritative and is edited in the settings pane. For free-text hosts, the old `localStorage` path still applies.
+
+- [ ] **Step 4: One-time migration of localStorage commands**
+
+Add and call this once during page initialization, after `refresh_host_list` is defined:
+
+```javascript
+  function migrate_local_commands() {
+    if (!user_hosts_enabled) return;
+    if (window.localStorage.getItem('webssh_migrated_commands')) return;
+    var found = [];
+    for (var i = 0; i < window.localStorage.length; i++) {
+      var key = window.localStorage.key(i);
+      if (key && key.indexOf('command:') === 0) {
+        var parts = key.split(':');
+        found.push({
+          hostname: parts[1],
+          port: window.parseInt(parts[2], 10) || 22,
+          command: window.localStorage.getItem(key)
+        });
+      }
+    }
+    if (!found.length) {
+      window.localStorage.setItem('webssh_migrated_commands', '1');
+      return;
+    }
+    $.get('/api/hosts').done(function(data) {
+      var hosts = data.user_hosts || [];
+      var index = {};
+      for (var i = 0; i < hosts.length; i++) {
+        index[hosts[i].hostname + ':' + hosts[i].port] = hosts[i];
+      }
+      var changed = false;
+      for (var j = 0; j < found.length; j++) {
+        var match = index[found[j].hostname + ':' + found[j].port];
+        if (match && !match.default_command) {
+          match.default_command = found[j].command;
+          changed = true;
+        }
+      }
+      if (!changed) {
+        window.localStorage.setItem('webssh_migrated_commands', '1');
+        return;
+      }
+      var payload = [];
+      for (var k = 0; k < hosts.length; k++) {
+        payload.push({
+          name: hosts[k].name, hostname: hosts[k].hostname,
+          port: hosts[k].port, host_key: hosts[k].host_keys || [],
+          username: hosts[k].username || '',
+          default_command: hosts[k].default_command || ''
+        });
+      }
+      $.ajax({
+        url: '/api/hosts', type: 'PUT', contentType: 'application/json',
+        headers: {'X-Xsrftoken': get_xsrf_token()},
+        data: JSON.stringify({hosts: payload})
+      }).done(function() {
+        window.localStorage.setItem('webssh_migrated_commands', '1');
+        refresh_host_list();
+      });
+    });
+  }
+```
+
+The guard key means the migration runs at most once per browser, and it never overwrites a `default_command` the user has already set.
+
+- [ ] **Step 5: Apply terminal preferences**
+
+In the terminal construction block, make stored preferences the fallback beneath URL parameters, preserving the existing precedence where a URL parameter always wins:
+
+```javascript
+          termOptions = {
+            cursorBlink: user_settings.cursor_blink !== false,
+            theme: {
+              background: url_opts_data.bgcolor || user_settings.background || 'black',
+              foreground: url_opts_data.fontcolor || user_settings.foreground || 'white',
+              cursor: url_opts_data.cursor || user_settings.cursor ||
+                      url_opts_data.fontcolor || user_settings.foreground || 'white'
+            }
+          };
+```
+
+and extend the font size block below it:
+
+```javascript
+      var fontsize = window.parseInt(
+        url_opts_data.fontsize || user_settings.font_size, 10);
+      if (fontsize && fontsize > 0) {
+        termOptions.fontSize = fontsize;
+      }
+```
+
+Also apply the stored terminal type by setting the hidden `#term` input during initialization:
+
+```javascript
+  if (user_settings.term) {
+    $('#term').val(user_settings.term);
+  }
+  if (user_settings.key_source === 'stored' && user_key_enabled) {
+    $('#key_source_stored').prop('checked', true).trigger('change');
+  }
+```
+
+- [ ] **Step 6: Manual verification**
+
+Restart the server as in Task 7, then confirm:
+
+- [ ] Connect to a host, reload the page: hostname, username, and port are restored.
+- [ ] Change the font size in Settings, save, open a new connection: the new terminal uses that size.
+- [ ] A URL with `?fontsize=20` still overrides the stored font size.
+- [ ] Open the browser's dev tools, inspect `/api/settings`: the stored JSON contains no `credential`, `totp`, `password`, or `passphrase` key.
+- [ ] With `user_hosts` disabled, everything still persists via `localStorage` exactly as before.
+- [ ] Set a default command in `localStorage` for a host you have also saved server-side, reload twice: the command migrates onto the host record and the migration does not run again.
+
+- [ ] **Step 7: Run the suite and commit**
+
+Run: `.venv/bin/python -m pytest -q`
+Expected: PASS, no regressions.
+
+```bash
+git add webssh/static/js/main.js
+git commit -m "feat: roam user preferences through server-side storage"
+```
+
+---
+
+### Task 9: Documentation
+
+**Files:**
+- Modify: `config.yaml.example`
+- Modify: `README.md`
+
+**Interfaces:**
+- Consumes: the config keys from Task 3.
+- Produces: nothing code depends on.
+
+- [ ] **Step 1: Document the config keys**
+
+Append to `config.yaml.example`, after the `userheader` block:
+
+```yaml
+# User-managed hosts and settings (optional)
+# When true, authenticated users can add their own hosts and manage terminal
+# preferences from the in-app Settings tab. Their hosts and settings are stored
+# server-side so they roam across browsers and machines.
+#
+# SECURITY: enabling this lets users connect to hosts outside the `hosts`
+# allowlist above. Leave it false if the allowlist is meant to be a hard
+# restriction. Personal hosts can pin their own host_key, which is required
+# when policy is `reject`.
+#
+# Requires an authenticated username via userheader. Set trusted_proxies so the
+# header cannot be spoofed.
+# user_hosts: true
+
+# Directory for per-user hosts and settings (optional)
+# Defaults to userkeydir when unset, placing hosts.json and settings.json
+# alongside each user's SSH key.
+# userdatadir: /var/lib/webssh/user-data
+```
+
+- [ ] **Step 2: Document the feature in the README**
+
+Add to the Features list:
+
+```markdown
+* Per-user host lists and preferences that roam across browsers and machines
+```
+
+And add a section after the Configuration section:
+
+````markdown
+### User-managed hosts
+
+With `user_hosts: true`, each authenticated user gets a Settings tab where they
+can add their own hosts and set terminal preferences. Both are stored on the
+server under `userdatadir` (defaulting to `userkeydir`), so they follow the user
+between browsers and machines.
+
+```yaml
+user_hosts: true
+userdatadir: /var/lib/webssh/user-data
+userheader: X-Authentik-Username
+trusted_proxies:
+  - 10.0.0.1
+```
+
+Administrator hosts from `hosts:` remain read-only and always take precedence: if
+a user saves a host with the same hostname and port as an administrator entry,
+the administrator's host key pin is the one used.
+
+Enabling this means users can connect to hosts outside the `hosts:` allowlist. If
+that allowlist is a security boundary rather than a convenience list, leave
+`user_hosts` off.
+````
+
+- [ ] **Step 3: Verify and commit**
+
+Run: `.venv/bin/python -m pytest -q`
+Expected: PASS, 0 failures.
+
+```bash
+git add config.yaml.example README.md
+git commit -m "docs: document user_hosts and userdatadir"
+```
+
+---
+
+## Verification Checklist
+
+Before considering the feature complete:
+
+- [ ] `.venv/bin/python -m pytest -q` passes with zero failures
+- [ ] With `user_hosts` unset, a diff of behavior against `main` shows no change: the host dropdown, allowlist enforcement, and `localStorage` persistence all behave identically
+- [ ] A user host cannot override an administrator host key pin (Task 5 test)
+- [ ] Stored JSON contains no credentials (Task 2 and Task 8 checks)
+- [ ] `hosts.json` and `settings.json` are mode `0600`
+- [ ] The manual UI checks in Tasks 7 and 8 all pass

--- a/docs/superpowers/plans/2026-07-27-user-editable-hosts.md
+++ b/docs/superpowers/plans/2026-07-27-user-editable-hosts.md
@@ -56,7 +56,8 @@ class TestParseHostEntry(unittest.TestCase):
 
     def test_full_entry_with_string_host_key(self):
         from webssh.settings import parse_host_entry
-        key = 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIAbcdefgh'
+        key = ('ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGrAb7GEqLHlbAF9gMdvDZzd'
+               'Knd2MlrZ2sAs5qF7XMRF')
         host = parse_host_entry({
             'name': 'Prod', 'hostname': '10.0.1.5', 'port': 2222,
             'host_key': key,
@@ -211,7 +212,8 @@ from webssh.user_data import (
 )
 
 
-VALID_KEY = 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIAbcdefgh'
+VALID_KEY = ('ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGrAb7GEqLHlbAF9gMdvDZzd'
+             'Knd2MlrZ2sAs5qF7XMRF')
 
 
 class TestGetUserDataDir(unittest.TestCase):

--- a/docs/superpowers/plans/2026-08-01-js-test-coverage.md
+++ b/docs/superpowers/plans/2026-08-01-js-test-coverage.md
@@ -1,0 +1,1179 @@
+# JavaScript Test Coverage Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give the user-hosts client code a dependency-free unit test suite that runs in CI on every pull request.
+
+**Architecture:** Decision logic moves out of `webssh/static/js/main.js` into a new pure module `webssh/static/js/user-hosts.js`; DOM reading stays in `main.js`, which reads the pane into plain values and passes them to the module. Because the extracted surface is pure, the tests need no jsdom, no jQuery, and no npm packages — Node's built-in `node --test` is the entire harness.
+
+**Tech Stack:** ES5 JavaScript, Node 20+ `node:test` and `node:assert`, GitHub Actions.
+
+**Spec:** `docs/superpowers/specs/2026-07-31-js-test-coverage-design.md`
+
+## Global Constraints
+
+- **Zero dependencies.** `package.json` declares no `dependencies` and no `devDependencies`. Nothing is installed in CI; there is no lockfile. If you find yourself wanting a package, stop and report instead.
+- **ES5 only in `webssh/static/js/`.** `var` only, no arrow functions, no `const`/`let`, no template literals, no `Object.assign`. The module ships to browsers alongside the existing ES5 `main.js`. Test files under `tests/js/` also stay ES5 for consistency, though Node would accept more.
+- **The extraction must be behaviour-preserving.** Every moved function keeps its current semantics exactly, including edge cases that look like bugs. This is a refactor plus tests, not a redesign. If you believe a moved function is wrong, report it — do not fix it here.
+- **`host_key` / `host_keys` asymmetry is deliberate and long-standing.** Input and submitted payloads use `host_key` (singular; string or list). Stored and returned records use `host_keys` (plural, always a list). Getting this backwards silently drops users' pinned host keys.
+- **Secrets never leave the client.** No function in the new module may ever emit `credential`, `totp`, `password`, `passphrase`, or `privatekey`. Task 6 enforces this as a property over every builder.
+- **The Python suite must stay green at 234 passed.** Run `/home/ryan/github/rgregg/webssh/.venv/bin/python -m pytest -q` (the venv lives at the ORIGINAL repo path, not the worktree).
+
+**Baseline:** `node --test tests/js/` does not exist yet. `pytest` is green at 234. Verify the Python baseline before starting.
+
+**A note on why this exists.** Review of the client-side tasks found one Critical and eight Important defects, versus roughly one per server-side task. Every test in this plan traces to a defect that review or browser testing actually found; the table in each task names it. Do not add tests that guard nothing — they cost maintenance and buy no signal.
+
+---
+
+### Task 1: Harness, module skeleton, and `validate_port`
+
+The scaffold rides along with the first real extraction so that the toolchain is proven end to end by a test that matters, rather than by a placeholder.
+
+**Files:**
+- Create: `package.json`, `webssh/static/js/user-hosts.js`, `tests/js/user-hosts.test.js`
+- Modify: `webssh/templates/index.html:176-191` (script tags), `.github/workflows/python.yml`
+- Modify: `webssh/static/js/main.js:879-917` (`collect_host_rows` port branch)
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: global `webssh_hosts` (also `module.exports` under Node) with `validate_port(text)` returning one of exactly three shapes:
+  - `{omit: true}` — the field was blank; the caller must omit `port` entirely so the server applies its documented default of 22
+  - `{port: <int>}` — valid, 1–65535
+  - `{invalid: true}` — present but not an integer in range. The caller composes the user-facing message, because it needs the host name.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/js/user-hosts.test.js`:
+
+```js
+'use strict';
+
+var test = require('node:test');
+var assert = require('node:assert');
+var hosts = require('../../webssh/static/js/user-hosts.js');
+
+test('validate_port omits a blank port so the server default applies', function () {
+  assert.deepStrictEqual(hosts.validate_port(''), {omit: true});
+  assert.deepStrictEqual(hosts.validate_port('   '), {omit: true});
+});
+
+test('validate_port accepts values in range', function () {
+  assert.deepStrictEqual(hosts.validate_port('22'), {port: 22});
+  assert.deepStrictEqual(hosts.validate_port('2222'), {port: 2222});
+  assert.deepStrictEqual(hosts.validate_port('65535'), {port: 65535});
+  assert.deepStrictEqual(hosts.validate_port('1'), {port: 1});
+});
+
+test('validate_port rejects out-of-range values instead of rewriting them', function () {
+  // Regression: a typo was once silently clamped to 22, routing around the
+  // server-side 1-65535 check and connecting the user to a port they did
+  // not type.
+  assert.deepStrictEqual(hosts.validate_port('0'), {invalid: true});
+  assert.deepStrictEqual(hosts.validate_port('-5'), {invalid: true});
+  assert.deepStrictEqual(hosts.validate_port('99999'), {invalid: true});
+  assert.deepStrictEqual(hosts.validate_port('65536'), {invalid: true});
+});
+
+test('validate_port rejects non-numeric text', function () {
+  assert.deepStrictEqual(hosts.validate_port('abc'), {invalid: true});
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `node --test tests/js/`
+Expected: FAIL — `Cannot find module '../../webssh/static/js/user-hosts.js'`
+
+- [ ] **Step 3: Create the module**
+
+Create `webssh/static/js/user-hosts.js`:
+
+```js
+/*jslint browser:true */
+/*
+ * Pure decision logic for the user-managed hosts and settings feature.
+ *
+ * This module holds no DOM access and no jQuery dependency: main.js reads
+ * the settings pane into plain values and passes them here. That keeps this
+ * file unit-testable under `node --test` with no browser and no packages.
+ */
+
+var webssh_hosts = (function () {
+  'use strict';
+
+  // Returns exactly one of {omit: true}, {port: n}, or {invalid: true}.
+  // A blank port is omitted rather than defaulted here, so the server
+  // applies its own documented default; a typed value is never rewritten.
+  function validate_port(text) {
+    var trimmed = (text === undefined || text === null) ? '' : String(text).trim();
+    if (!trimmed) {
+      return {omit: true};
+    }
+    var port = parseInt(trimmed, 10);
+    if (!(port > 0 && port <= 65535)) {
+      return {invalid: true};
+    }
+    return {port: port};
+  }
+
+  return {
+    validate_port: validate_port
+  };
+}());
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = webssh_hosts;
+}
+```
+
+Note `parseInt('22abc', 10)` is `22`, matching the current behaviour in `main.js:906`. Preserve that; do not tighten it.
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `node --test tests/js/`
+Expected: PASS, 4 tests.
+
+- [ ] **Step 5: Add package.json**
+
+Create `package.json`:
+
+```json
+{
+  "name": "webssh-client-tests",
+  "private": true,
+  "description": "Unit tests for the WebSSH browser client. No runtime dependencies.",
+  "engines": {
+    "node": ">=20"
+  },
+  "scripts": {
+    "test": "node --test tests/js/"
+  }
+}
+```
+
+Run: `npm test`
+Expected: PASS, same 4 tests. There is nothing to install first — that is the point.
+
+- [ ] **Step 6: Load the module in the browser**
+
+In `webssh/templates/index.html`, add the new script immediately before `main.js` (currently line 191), so the global exists when `main.js` runs:
+
+```html
+    <script src="static/js/user-hosts.js"></script>
+    <script src="static/js/main.js"></script>
+```
+
+- [ ] **Step 7: Use `validate_port` from main.js**
+
+In `main.js`, replace the port branch of `collect_host_rows` (lines 902-913) with a call into the module. The surrounding function is otherwise unchanged in this task:
+
+```js
+      // Leave port unset when blank so the server applies its documented
+      // default; never rewrite a value the user actually typed.
+      var port_text = row.find('.host-port').val().trim();
+      var port_result = webssh_hosts.validate_port(port_text);
+      if (port_result.invalid) {
+        row.find('.host-port').addClass('input-error');
+        error = 'Invalid port "' + port_text + '" for host "' + name + '" (must be 1-65535).';
+        return;
+      }
+      if (port_result.port) {
+        host.port = port_result.port;
+      }
+```
+
+- [ ] **Step 8: Add the CI job**
+
+In `.github/workflows/python.yml`, add a `js` job alongside `lint` and `test`:
+
+```yaml
+  js:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - run: node --test tests/js/
+```
+
+Then add `js` to the `docker` job's `needs:` list so a JavaScript failure blocks the release exactly as a Python failure does. It currently reads `needs: [lint, test]`; make it `needs: [lint, test, js]`.
+
+- [ ] **Step 9: Verify nothing regressed**
+
+Run: `node --test tests/js/`
+Expected: PASS, 4 tests.
+
+Run: `/home/ryan/github/rgregg/webssh/.venv/bin/python -m pytest -q`
+Expected: PASS, 234 passed. The template change touches a rendered page, so a Python failure here means the script tag broke something.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add package.json webssh/static/js/user-hosts.js tests/js/user-hosts.test.js \
+        webssh/templates/index.html webssh/static/js/main.js .github/workflows/python.yml
+git commit -m "test: add dependency-free JS harness and cover port validation"
+```
+
+---
+
+### Task 2: `build_host_payload`
+
+**Files:**
+- Modify: `webssh/static/js/user-hosts.js`, `tests/js/user-hosts.test.js`
+- Modify: `webssh/static/js/main.js:879-917` (`collect_host_rows`)
+
+**Interfaces:**
+- Consumes: `validate_port` from Task 1.
+- Produces: `build_host_payload(rows)` where `rows` is an array of plain objects
+  `{name, hostname, port_text, keys_text, username, default_command}` (all strings,
+  untrimmed as read from the DOM). Returns
+  `{hosts: [...], error: null|string, error_index: -1|<int>}`.
+  `error_index` is new: `main.js` needs it to mark the offending row, which the
+  old inline version did directly. Submitted hosts use `host_key` (singular).
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/js/user-hosts.test.js`:
+
+```js
+function row(over) {
+  var base = {name: '', hostname: '', port_text: '', keys_text: '',
+              username: '', default_command: ''};
+  for (var k in over) { base[k] = over[k]; }
+  return base;
+}
+
+test('build_host_payload maps a full row and trims every field', function () {
+  var out = hosts.build_host_payload([row({
+    name: '  homelab ', hostname: ' nas.lan ', port_text: '2222',
+    keys_text: ' ssh-ed25519 AAAA ', username: ' ryan ',
+    default_command: ' tmux attach '
+  })]);
+  assert.strictEqual(out.error, null);
+  assert.deepStrictEqual(out.hosts, [{
+    name: 'homelab', hostname: 'nas.lan', host_key: ['ssh-ed25519 AAAA'],
+    username: 'ryan', default_command: 'tmux attach', port: 2222
+  }]);
+});
+
+test('build_host_payload emits host_key singular, never host_keys', function () {
+  // The server consumes host_key and returns host_keys. Sending the wrong
+  // one silently drops the user's pinned keys, which downgrades the host to
+  // the global policy.
+  var out = hosts.build_host_payload([row({
+    hostname: 'a.com', keys_text: 'ssh-ed25519 AAAA'
+  })]);
+  assert.ok('host_key' in out.hosts[0]);
+  assert.ok(!('host_keys' in out.hosts[0]));
+});
+
+test('build_host_payload splits multiple keys and drops blank lines', function () {
+  var out = hosts.build_host_payload([row({
+    hostname: 'a.com', keys_text: 'ssh-ed25519 AAA\n\n  \nssh-rsa BBB\n'
+  })]);
+  assert.deepStrictEqual(out.hosts[0].host_key, ['ssh-ed25519 AAA', 'ssh-rsa BBB']);
+});
+
+test('build_host_payload defaults an empty name to the hostname', function () {
+  var out = hosts.build_host_payload([row({hostname: 'nas.lan'})]);
+  assert.strictEqual(out.hosts[0].name, 'nas.lan');
+});
+
+test('build_host_payload omits port entirely when blank', function () {
+  var out = hosts.build_host_payload([row({hostname: 'a.com'})]);
+  assert.ok(!('port' in out.hosts[0]),
+            'a blank port must be absent, not null/0/NaN, so the server defaults it');
+});
+
+test('build_host_payload skips rows with a blank hostname', function () {
+  var out = hosts.build_host_payload([
+    row({hostname: 'a.com'}),
+    row({name: 'half-filled', keys_text: 'ssh-ed25519 AAA'}),
+    row({hostname: 'b.com'})
+  ]);
+  assert.strictEqual(out.hosts.length, 2);
+  assert.deepStrictEqual([out.hosts[0].hostname, out.hosts[1].hostname],
+                         ['a.com', 'b.com']);
+});
+
+test('build_host_payload reports an invalid port with the offending row index', function () {
+  var out = hosts.build_host_payload([
+    row({hostname: 'a.com'}),
+    row({name: 'db', hostname: 'b.com', port_text: '99999'})
+  ]);
+  assert.strictEqual(out.error,
+    'Invalid port "99999" for host "db" (must be 1-65535).');
+  assert.strictEqual(out.error_index, 1);
+});
+
+test('build_host_payload stops at the first invalid row', function () {
+  var out = hosts.build_host_payload([
+    row({hostname: 'a.com', port_text: '0'}),
+    row({hostname: 'b.com', port_text: '70000'})
+  ]);
+  assert.strictEqual(out.error_index, 0);
+});
+
+test('build_host_payload returns an empty list for no rows', function () {
+  // An explicit empty list is a legitimate "clear my hosts", distinct from
+  // a failure, and the server honours it as such.
+  assert.deepStrictEqual(hosts.build_host_payload([]),
+                         {hosts: [], error: null, error_index: -1});
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `node --test tests/js/`
+Expected: FAIL — `hosts.build_host_payload is not a function`
+
+- [ ] **Step 3: Implement it**
+
+Add to `user-hosts.js` above the `return` block, and add `build_host_payload` to the returned object:
+
+```js
+  function split_keys(text) {
+    var raw = (text === undefined || text === null) ? '' : String(text);
+    var parts = raw.split('\n');
+    var cleaned = [];
+    for (var i = 0; i < parts.length; i++) {
+      var k = parts[i].trim();
+      if (k) {
+        cleaned.push(k);
+      }
+    }
+    return cleaned;
+  }
+
+  function trimmed(value) {
+    return (value === undefined || value === null) ? '' : String(value).trim();
+  }
+
+  // rows: [{name, hostname, port_text, keys_text, username, default_command}]
+  // Rows with a blank hostname are skipped, matching the pane's behaviour of
+  // ignoring a half-filled row rather than submitting it.
+  function build_host_payload(rows) {
+    var result = [];
+    for (var i = 0; i < rows.length; i++) {
+      var r = rows[i];
+      var hostname = trimmed(r.hostname);
+      if (!hostname) {
+        continue;
+      }
+      var name = trimmed(r.name) || hostname;
+      var host = {
+        name: name,
+        hostname: hostname,
+        host_key: split_keys(r.keys_text),
+        username: trimmed(r.username),
+        default_command: trimmed(r.default_command)
+      };
+      var port_result = validate_port(r.port_text);
+      if (port_result.invalid) {
+        return {
+          hosts: [],
+          error: 'Invalid port "' + trimmed(r.port_text) +
+                 '" for host "' + name + '" (must be 1-65535).',
+          error_index: i
+        };
+      }
+      if (port_result.port) {
+        host.port = port_result.port;
+      }
+      result.push(host);
+    }
+    return {hosts: result, error: null, error_index: -1};
+  }
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `node --test tests/js/`
+Expected: PASS, 13 tests.
+
+- [ ] **Step 5: Rewrite collect_host_rows to use it**
+
+Replace `collect_host_rows` in `main.js` entirely. It now does DOM reading only:
+
+```js
+  function collect_host_rows(pane) {
+    var rows = [];
+    var row_els = [];
+    pane.find('#user-host-rows .host-port').removeClass('input-error');
+    pane.find('#user-host-rows tr.user-host').each(function() {
+      var row = $(this);
+      row_els.push(row);
+      rows.push({
+        name: row.find('.host-name').val(),
+        hostname: row.find('.host-hostname').val(),
+        port_text: row.find('.host-port').val(),
+        keys_text: row.find('.host-keys').val(),
+        username: row.find('.host-username').val(),
+        default_command: row.find('.host-command').val()
+      });
+    });
+
+    var built = webssh_hosts.build_host_payload(rows);
+    if (built.error && built.error_index >= 0) {
+      row_els[built.error_index].find('.host-port').addClass('input-error');
+    }
+    return {hosts: built.hosts, error: built.error};
+  }
+```
+
+The returned shape `{hosts, error}` is unchanged, so the caller needs no edit.
+
+- [ ] **Step 6: Verify nothing regressed**
+
+Run: `node --test tests/js/`
+Expected: PASS, 13 tests.
+
+Run: `/home/ryan/github/rgregg/webssh/.venv/bin/python -m pytest -q`
+Expected: PASS, 234 passed.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add webssh/static/js/user-hosts.js tests/js/user-hosts.test.js webssh/static/js/main.js
+git commit -m "test: extract and cover host payload construction"
+```
+
+---
+
+### Task 3: `merge_settings` and `roaming_update`
+
+**Files:**
+- Modify: `webssh/static/js/user-hosts.js`, `tests/js/user-hosts.test.js`
+- Modify: `webssh/static/js/main.js:920-945` (`collect_settings`), `:429-446` (`store_items`)
+
+**Interfaces:**
+- Consumes: the private `trimmed(value)` helper added to `user-hosts.js` in Task 2.
+- Produces:
+  - `ROAMING_FIELDS` — the exported map `{hostname: 'last_hostname', username: 'last_username', port: 'last_port'}`. `main.js` stops defining its own and uses this one, so there is a single source of truth.
+  - `merge_settings(current, ui)` where `ui` is `{font_size_text, background, foreground, cursor, encoding, term, cursor_blink, key_source}`. Returns the settings object to PUT.
+  - `roaming_update(name, value)` returning `{key: <stored key>, value: <string|int>}` or `null` when the field does not roam or the value is unusable.
+
+**Naming note:** the spec calls this `roaming_from_form(names, values)`, taking the
+whole field list. A per-field signature is used instead because the actual call
+site in `store_items` already loops field by field and needs the localStorage
+write interleaved; a batch signature would force that loop to run twice. The
+behaviour is identical. Use `roaming_update`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/js/user-hosts.test.js`:
+
+```js
+function ui(over) {
+  var base = {font_size_text: '', background: '', foreground: '', cursor: '',
+              encoding: '', term: '', cursor_blink: true, key_source: 'upload'};
+  for (var k in over) { base[k] = over[k]; }
+  return base;
+}
+
+test('merge_settings carries roamed last-used values forward', function () {
+  // Regression: the pane only knows appearance keys, and the settings PUT
+  // replaces the whole blob, so every save used to wipe the roamed values.
+  // That is invisible on one machine because localStorage covers it, and
+  // only shows up on a second machine -- which is the point of roaming.
+  var current = {last_hostname: 'nas.lan', last_username: 'ryan', last_port: 2222};
+  var out = hosts.merge_settings(current, ui({font_size_text: '16'}));
+  assert.strictEqual(out.last_hostname, 'nas.lan');
+  assert.strictEqual(out.last_username, 'ryan');
+  assert.strictEqual(out.last_port, 2222);
+  assert.strictEqual(out.font_size, 16);
+});
+
+test('merge_settings omits roaming keys absent from current settings', function () {
+  var out = hosts.merge_settings({}, ui({font_size_text: '16'}));
+  assert.ok(!('last_hostname' in out),
+            'absent keys must be omitted, not sent as null/undefined');
+  assert.ok(!('last_port' in out));
+});
+
+test('merge_settings carries only the three known roaming keys', function () {
+  var out = hosts.merge_settings(
+    {last_hostname: 'a', nonsense: 'x', credential: 'secret'}, ui({}));
+  assert.strictEqual(out.last_hostname, 'a');
+  assert.ok(!('nonsense' in out));
+  assert.ok(!('credential' in out));
+});
+
+test('merge_settings includes appearance values only when non-empty', function () {
+  var out = hosts.merge_settings({}, ui({background: ' black ', foreground: ''}));
+  assert.strictEqual(out.background, 'black');
+  assert.ok(!('foreground' in out));
+});
+
+test('merge_settings omits a non-positive font size', function () {
+  assert.ok(!('font_size' in hosts.merge_settings({}, ui({font_size_text: ''}))));
+  assert.ok(!('font_size' in hosts.merge_settings({}, ui({font_size_text: '0'}))));
+  assert.ok(!('font_size' in hosts.merge_settings({}, ui({font_size_text: 'abc'}))));
+});
+
+test('merge_settings always includes cursor_blink and key_source', function () {
+  var out = hosts.merge_settings({}, ui({cursor_blink: false, key_source: 'stored'}));
+  assert.strictEqual(out.cursor_blink, false);
+  assert.strictEqual(out.key_source, 'stored');
+});
+
+test('roaming_update maps only the three roaming form fields', function () {
+  assert.deepStrictEqual(hosts.roaming_update('hostname', 'nas.lan'),
+                         {key: 'last_hostname', value: 'nas.lan'});
+  assert.deepStrictEqual(hosts.roaming_update('username', 'ryan'),
+                         {key: 'last_username', value: 'ryan'});
+  assert.strictEqual(hosts.roaming_update('credential', 'hunter2'), null);
+  assert.strictEqual(hosts.roaming_update('totp', '123456'), null);
+  assert.strictEqual(hosts.roaming_update('passphrase', 'x'), null);
+});
+
+test('roaming_update coerces port to an integer', function () {
+  // The server validates last_port as an int 1-65535; a string would be
+  // rejected with a 400 the user never sees.
+  assert.deepStrictEqual(hosts.roaming_update('port', '2222'),
+                         {key: 'last_port', value: 2222});
+  assert.strictEqual(typeof hosts.roaming_update('port', '2222').value, 'number');
+});
+
+test('roaming_update drops an unusable port instead of sending it', function () {
+  assert.strictEqual(hosts.roaming_update('port', 'abc'), null);
+  assert.strictEqual(hosts.roaming_update('port', '0'), null);
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `node --test tests/js/`
+Expected: FAIL — `hosts.merge_settings is not a function`
+
+- [ ] **Step 3: Implement them**
+
+Add to `user-hosts.js`, and add `ROAMING_FIELDS`, `merge_settings`, and `roaming_update` to the returned object:
+
+```js
+  // Form field name -> stored settings key. These three are the ONLY fields
+  // that roam. Everything else in the form, including credential and totp,
+  // is deliberately absent so secrets cannot reach the server structurally.
+  var ROAMING_FIELDS = {
+    hostname: 'last_hostname',
+    username: 'last_username',
+    port: 'last_port'
+  };
+
+  var APPEARANCE_KEYS = ['background', 'foreground', 'cursor', 'encoding', 'term'];
+
+  function merge_settings(current, ui) {
+    var settings = {};
+    var size = parseInt(ui.font_size_text, 10);
+    if (size > 0) {
+      settings.font_size = size;
+    }
+    for (var i = 0; i < APPEARANCE_KEYS.length; i++) {
+      var key = APPEARANCE_KEYS[i];
+      var value = trimmed(ui[key]);
+      if (value) {
+        settings[key] = value;
+      }
+    }
+    settings.cursor_blink = ui.cursor_blink;
+    settings.key_source = ui.key_source;
+    // The settings PUT replaces the whole stored blob and this pane only
+    // knows appearance keys, so carry the roamed values forward. Only the
+    // known keys, to keep the secrets invariant structural.
+    for (var name in ROAMING_FIELDS) {
+      var roam_key = ROAMING_FIELDS[name];
+      if (current[roam_key] !== undefined) {
+        settings[roam_key] = current[roam_key];
+      }
+    }
+    return settings;
+  }
+
+  function roaming_update(name, value) {
+    var roam_key = ROAMING_FIELDS[name];
+    if (!roam_key) {
+      return null;
+    }
+    if (name === 'port') {
+      var port = parseInt(value, 10);
+      if (!(port > 0)) {
+        return null;
+      }
+      return {key: roam_key, value: port};
+    }
+    return {key: roam_key, value: value};
+  }
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `node --test tests/js/`
+Expected: PASS, 22 tests.
+
+- [ ] **Step 5: Use them from main.js**
+
+Delete the `ROAMING_FIELDS` definition at `main.js:422-426` and replace every reference to it with `webssh_hosts.ROAMING_FIELDS`. Then rewrite the two call sites.
+
+`collect_settings` becomes DOM reading plus one call:
+
+```js
+  function collect_settings(pane) {
+    return webssh_hosts.merge_settings(user_settings, {
+      font_size_text: pane.find('#set-font-size').val(),
+      background: pane.find('#set-background').val(),
+      foreground: pane.find('#set-foreground').val(),
+      cursor: pane.find('#set-cursor').val(),
+      encoding: pane.find('#set-encoding').val(),
+      term: pane.find('#set-term').val(),
+      cursor_blink: pane.find('#set-cursor-blink').is(':checked'),
+      key_source: pane.find('#set-key-source').val()
+    });
+  }
+```
+
+The roaming branch of `store_items` becomes:
+
+```js
+      if (value) {
+        window.localStorage.setItem(name, value);
+        var roamed = webssh_hosts.roaming_update(name, value);
+        if (roamed) {
+          user_settings[roamed.key] = roamed.value;
+        }
+      }
+```
+
+- [ ] **Step 6: Verify nothing regressed**
+
+Run: `node --test tests/js/`
+Expected: PASS, 22 tests.
+
+Run: `/home/ryan/github/rgregg/webssh/.venv/bin/python -m pytest -q`
+Expected: PASS, 234 passed.
+
+Then confirm by reading that no reference to a bare `ROAMING_FIELDS` survives in `main.js`:
+
+Run: `grep -n 'ROAMING_FIELDS' webssh/static/js/main.js`
+Expected: every hit is prefixed `webssh_hosts.`
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add webssh/static/js/user-hosts.js tests/js/user-hosts.test.js webssh/static/js/main.js
+git commit -m "test: extract and cover settings merge and roaming fields"
+```
+
+---
+
+### Task 4: `resolve_terminal_options` and `save_error_text`
+
+**Files:**
+- Modify: `webssh/static/js/user-hosts.js`, `tests/js/user-hosts.test.js`
+- Modify: `webssh/static/js/main.js:1185-1199` (`termOptions`), `:1047-1055` (`save_error_text`)
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks.
+- Produces:
+  - `resolve_terminal_options(url_opts, stored)` returning `{cursorBlink, theme: {background, foreground, cursor}}` plus `fontSize` only when a positive size resolves.
+  - `save_error_text(status, body)` where `body` is the parsed JSON response or `null`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/js/user-hosts.test.js`:
+
+```js
+test('resolve_terminal_options lets a URL parameter beat a stored value', function () {
+  // Existing shared links carry ?fontsize= and ?bgcolor=; a stored
+  // preference must never override an explicit URL parameter.
+  var out = hosts.resolve_terminal_options(
+    {fontsize: '20', bgcolor: 'navy'},
+    {font_size: 19, background: 'black'});
+  assert.strictEqual(out.fontSize, 20);
+  assert.strictEqual(out.theme.background, 'navy');
+});
+
+test('resolve_terminal_options falls back to stored values', function () {
+  var out = hosts.resolve_terminal_options({}, {font_size: 19, background: 'black'});
+  assert.strictEqual(out.fontSize, 19);
+  assert.strictEqual(out.theme.background, 'black');
+});
+
+test('resolve_terminal_options falls back to built-in defaults', function () {
+  var out = hosts.resolve_terminal_options({}, {});
+  assert.strictEqual(out.theme.background, 'black');
+  assert.strictEqual(out.theme.foreground, 'white');
+  assert.strictEqual(out.theme.cursor, 'white');
+  assert.strictEqual(out.cursorBlink, true);
+});
+
+test('resolve_terminal_options omits fontSize when nothing resolves', function () {
+  assert.ok(!('fontSize' in hosts.resolve_terminal_options({}, {})));
+});
+
+test('resolve_terminal_options ignores a malformed font size', function () {
+  // A bad stored value must not break the terminal.
+  assert.ok(!('fontSize' in hosts.resolve_terminal_options({fontsize: 'abc'}, {})));
+});
+
+test('resolve_terminal_options honours cursor_blink false', function () {
+  assert.strictEqual(
+    hosts.resolve_terminal_options({}, {cursor_blink: false}).cursorBlink, false);
+});
+
+test('resolve_terminal_options falls back through fontcolor for the cursor', function () {
+  var out = hosts.resolve_terminal_options({fontcolor: 'lime'}, {});
+  assert.strictEqual(out.theme.cursor, 'lime');
+});
+
+test('save_error_text surfaces the server message on 400', function () {
+  assert.strictEqual(
+    hosts.save_error_text(400, {error: 'Invalid port "99999" for host "db".'}),
+    'Invalid port "99999" for host "db".');
+});
+
+test('save_error_text falls back to a generic message on a bodyless 400', function () {
+  assert.strictEqual(hosts.save_error_text(400, null),
+                     'Rejected: check hostnames, ports, and host keys.');
+});
+
+test('save_error_text never surfaces server detail on 500', function () {
+  // Server-state messages can embed filesystem paths. The server already
+  // genericises them; the client must not undo that by echoing a body.
+  assert.strictEqual(
+    hosts.save_error_text(500, {error: '/var/lib/webssh/user-data denied'}),
+    'Save failed.');
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `node --test tests/js/`
+Expected: FAIL — `hosts.resolve_terminal_options is not a function`
+
+- [ ] **Step 3: Implement them**
+
+Add to `user-hosts.js` and to the returned object:
+
+```js
+  // Precedence: URL parameter, then stored preference, then built-in default.
+  function resolve_terminal_options(url_opts, stored) {
+    var options = {
+      cursorBlink: stored.cursor_blink !== false,
+      theme: {
+        background: url_opts.bgcolor || stored.background || 'black',
+        foreground: url_opts.fontcolor || stored.foreground || 'white',
+        cursor: url_opts.cursor || stored.cursor ||
+                url_opts.fontcolor || stored.foreground || 'white'
+      }
+    };
+    var fontsize = parseInt(url_opts.fontsize || stored.font_size, 10);
+    if (fontsize && fontsize > 0) {
+      options.fontSize = fontsize;
+    }
+    return options;
+  }
+
+  // A 400 describes the user's own input and is safe to show. Anything else
+  // may describe server state, so it gets a fixed generic message.
+  function save_error_text(status, body) {
+    if (status === 400) {
+      if (body && body.error) {
+        return body.error;
+      }
+      return 'Rejected: check hostnames, ports, and host keys.';
+    }
+    return 'Save failed.';
+  }
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `node --test tests/js/`
+Expected: PASS, 32 tests.
+
+- [ ] **Step 5: Use them from main.js**
+
+Replace the `termOptions` construction and the `fontsize` block (lines 1185-1199) with:
+
+```js
+          termOptions = webssh_hosts.resolve_terminal_options(
+            url_opts_data, user_settings);
+```
+
+Take care with the surrounding `var` declaration list: `termOptions` is currently the last declarator in a comma-separated chain, so keep the chain valid.
+
+Replace `save_error_text` with a thin adapter that keeps the existing single-argument call sites working:
+
+```js
+  function save_error_text(xhr) {
+    return webssh_hosts.save_error_text(
+      xhr ? xhr.status : 0, xhr ? xhr.responseJSON : null);
+  }
+```
+
+- [ ] **Step 6: Verify nothing regressed**
+
+Run: `node --test tests/js/`
+Expected: PASS, 32 tests.
+
+Run: `/home/ryan/github/rgregg/webssh/.venv/bin/python -m pytest -q`
+Expected: PASS, 234 passed.
+
+Run: `node --check webssh/static/js/main.js`
+Expected: no output. This catches a broken `var` chain from Step 5.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add webssh/static/js/user-hosts.js tests/js/user-hosts.test.js webssh/static/js/main.js
+git commit -m "test: extract and cover terminal option precedence and error text"
+```
+
+---
+
+### Task 5: Migration helpers
+
+The migration rewrites the user's entire host list, so a dropped field destroys pinned keys. It is the highest-consequence pure logic in the client.
+
+**Files:**
+- Modify: `webssh/static/js/user-hosts.js`, `tests/js/user-hosts.test.js`
+- Modify: `webssh/static/js/main.js:553-600` (`migrate_local_commands`)
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks.
+- Produces:
+  - `parse_command_key(key)` returning `{hostname, port}` or `null` for a key that is not a legacy command key.
+  - `merge_migrated_commands(stored_hosts, found)` where `stored_hosts` is the list from `GET /api/hosts` (records carrying `host_keys` plural) and `found` is `[{hostname, port, command}]`. Returns `{payload, changed}`; `payload` uses `host_key` singular and is `[]` when `changed` is false.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/js/user-hosts.test.js`:
+
+```js
+test('parse_command_key reads a legacy command key', function () {
+  assert.deepStrictEqual(hosts.parse_command_key('command:nas.lan:2222'),
+                         {hostname: 'nas.lan', port: 2222});
+});
+
+test('parse_command_key defaults a missing port to 22', function () {
+  assert.deepStrictEqual(hosts.parse_command_key('command:nas.lan:'),
+                         {hostname: 'nas.lan', port: 22});
+});
+
+test('parse_command_key ignores unrelated localStorage keys', function () {
+  assert.strictEqual(hosts.parse_command_key('hostname'), null);
+  assert.strictEqual(hosts.parse_command_key('webssh_migrated_commands'), null);
+  assert.strictEqual(hosts.parse_command_key(''), null);
+  assert.strictEqual(hosts.parse_command_key(null), null);
+});
+
+test('merge_migrated_commands preserves every field of every host', function () {
+  // This payload replaces the user's whole host list. A dropped field here
+  // silently destroys pinned host keys.
+  var stored = [{
+    name: 'homelab', hostname: 'nas.lan', port: 2222,
+    host_keys: ['ssh-ed25519 AAA'], username: 'ryan', default_command: ''
+  }];
+  var out = hosts.merge_migrated_commands(
+    stored, [{hostname: 'nas.lan', port: 2222, command: 'tmux attach'}]);
+  assert.strictEqual(out.changed, true);
+  assert.deepStrictEqual(out.payload, [{
+    name: 'homelab', hostname: 'nas.lan', port: 2222,
+    host_key: ['ssh-ed25519 AAA'], username: 'ryan',
+    default_command: 'tmux attach'
+  }]);
+});
+
+test('merge_migrated_commands converts host_keys to host_key', function () {
+  var out = hosts.merge_migrated_commands(
+    [{name: 'a', hostname: 'a.com', port: 22, host_keys: ['ssh-rsa AAA'],
+      username: '', default_command: ''}],
+    [{hostname: 'a.com', port: 22, command: 'htop'}]);
+  assert.deepStrictEqual(out.payload[0].host_key, ['ssh-rsa AAA']);
+  assert.ok(!('host_keys' in out.payload[0]));
+});
+
+test('merge_migrated_commands carries through hosts it does not migrate', function () {
+  var stored = [
+    {name: 'a', hostname: 'a.com', port: 22, host_keys: [], username: '',
+     default_command: ''},
+    {name: 'b', hostname: 'b.com', port: 22, host_keys: ['ssh-rsa BBB'],
+     username: 'bob', default_command: 'top'}
+  ];
+  var out = hosts.merge_migrated_commands(
+    stored, [{hostname: 'a.com', port: 22, command: 'htop'}]);
+  assert.strictEqual(out.payload.length, 2);
+  assert.deepStrictEqual(out.payload[1], {
+    name: 'b', hostname: 'b.com', port: 22, host_key: ['ssh-rsa BBB'],
+    username: 'bob', default_command: 'top'
+  });
+});
+
+test('merge_migrated_commands never invents a host', function () {
+  var out = hosts.merge_migrated_commands(
+    [], [{hostname: 'ghost.lan', port: 22, command: 'htop'}]);
+  assert.strictEqual(out.changed, false);
+  assert.deepStrictEqual(out.payload, []);
+});
+
+test('merge_migrated_commands does not overwrite an existing command', function () {
+  var out = hosts.merge_migrated_commands(
+    [{name: 'a', hostname: 'a.com', port: 22, host_keys: [], username: '',
+      default_command: 'already set'}],
+    [{hostname: 'a.com', port: 22, command: 'from localStorage'}]);
+  assert.strictEqual(out.changed, false);
+});
+
+test('merge_migrated_commands reports no change when nothing matches', function () {
+  var out = hosts.merge_migrated_commands(
+    [{name: 'a', hostname: 'a.com', port: 22, host_keys: [], username: '',
+      default_command: ''}],
+    [{hostname: 'other.lan', port: 22, command: 'htop'}]);
+  assert.strictEqual(out.changed, false);
+  assert.deepStrictEqual(out.payload, []);
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `node --test tests/js/`
+Expected: FAIL — `hosts.parse_command_key is not a function`
+
+- [ ] **Step 3: Implement them**
+
+Add to `user-hosts.js` and to the returned object:
+
+```js
+  // Legacy per-host default commands were stored under 'command:<host>:<port>'.
+  function parse_command_key(key) {
+    if (!key || String(key).indexOf('command:') !== 0) {
+      return null;
+    }
+    var parts = String(key).split(':');
+    return {
+      hostname: parts[1],
+      port: parseInt(parts[2], 10) || 22
+    };
+  }
+
+  // Returns the full replacement payload, since PUT /api/hosts replaces the
+  // whole list. Every stored field is carried through; only default_command
+  // is filled in, and only where the host has none.
+  function merge_migrated_commands(stored_hosts, found) {
+    var index = {};
+    var i;
+    for (i = 0; i < stored_hosts.length; i++) {
+      index[stored_hosts[i].hostname + ':' + stored_hosts[i].port] = stored_hosts[i];
+    }
+    var changed = false;
+    for (i = 0; i < found.length; i++) {
+      var match = index[found[i].hostname + ':' + found[i].port];
+      if (match && !match.default_command) {
+        match.default_command = found[i].command;
+        changed = true;
+      }
+    }
+    if (!changed) {
+      return {payload: [], changed: false};
+    }
+    var payload = [];
+    for (i = 0; i < stored_hosts.length; i++) {
+      var h = stored_hosts[i];
+      payload.push({
+        name: h.name,
+        hostname: h.hostname,
+        port: h.port,
+        host_key: h.host_keys || [],
+        username: h.username || '',
+        default_command: h.default_command || ''
+      });
+    }
+    return {payload: payload, changed: true};
+  }
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `node --test tests/js/`
+Expected: PASS, 41 tests.
+
+- [ ] **Step 5: Use them from main.js**
+
+In `migrate_local_commands`, replace the key-scanning loop with `parse_command_key`:
+
+```js
+    var found = [];
+    for (var i = 0; i < window.localStorage.length; i++) {
+      var key = window.localStorage.key(i);
+      var parsed = webssh_hosts.parse_command_key(key);
+      if (parsed) {
+        found.push({
+          hostname: parsed.hostname,
+          port: parsed.port,
+          command: window.localStorage.getItem(key)
+        });
+      }
+    }
+```
+
+and replace the index/merge/payload block inside the `$.get('/api/hosts').done(...)` callback with:
+
+```js
+      var merged = webssh_hosts.merge_migrated_commands(data.user_hosts || [], found);
+      if (!merged.changed) {
+        window.localStorage.setItem('webssh_migrated_commands', '1');
+        return;
+      }
+      var payload = merged.payload;
+```
+
+Leave every guard around this untouched: the `running` flag, the `.always`, the flag-setting, and the rule that the PUT is issued only inside the GET's `.done`. Those are what make the migration data-loss-safe.
+
+- [ ] **Step 6: Verify nothing regressed**
+
+Run: `node --test tests/js/`
+Expected: PASS, 41 tests.
+
+Run: `/home/ryan/github/rgregg/webssh/.venv/bin/python -m pytest -q`
+Expected: PASS, 234 passed.
+
+Run: `node --check webssh/static/js/main.js`
+Expected: no output.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add webssh/static/js/user-hosts.js tests/js/user-hosts.test.js webssh/static/js/main.js
+git commit -m "test: extract and cover legacy command migration"
+```
+
+---
+
+### Task 6: Secrets property test and developer documentation
+
+**Files:**
+- Modify: `tests/js/user-hosts.test.js`, `README.md`
+
+**Interfaces:**
+- Consumes: every builder from Tasks 1-5.
+- Produces: nothing other tasks rely on.
+
+- [ ] **Step 1: Write the property test**
+
+Append to `tests/js/user-hosts.test.js`. It is written as a property over all builder outputs so a field added later is covered without a new test:
+
+```js
+var SECRETS = ['credential', 'totp', 'password', 'passphrase', 'privatekey'];
+
+function assert_no_secrets(label, value) {
+  var text = JSON.stringify(value);
+  for (var i = 0; i < SECRETS.length; i++) {
+    assert.ok(text.indexOf(SECRETS[i]) === -1,
+              label + ' must never carry ' + SECRETS[i] + ', got: ' + text);
+  }
+}
+
+test('no builder output can carry a secret field', function () {
+  // The server whitelists keys as a backstop, but a client-side leak would
+  // still transmit the secret over the wire and log it on a validation error.
+  var poisoned = {
+    name: 'a', hostname: 'a.com', port_text: '22', keys_text: '',
+    username: 'u', default_command: 'cmd',
+    credential: 'hunter2', totp: '123456', password: 'p',
+    passphrase: 'pp', privatekey: 'pk'
+  };
+  assert_no_secrets('build_host_payload',
+                    hosts.build_host_payload([poisoned]).hosts);
+
+  var poisoned_current = {
+    last_hostname: 'nas.lan', credential: 'hunter2', totp: '123456',
+    password: 'p', passphrase: 'pp', privatekey: 'pk'
+  };
+  var poisoned_ui = {
+    font_size_text: '14', background: '', foreground: '', cursor: '',
+    encoding: '', term: '', cursor_blink: true, key_source: 'upload',
+    credential: 'hunter2', totp: '123456'
+  };
+  assert_no_secrets('merge_settings',
+                    hosts.merge_settings(poisoned_current, poisoned_ui));
+
+  assert_no_secrets('merge_migrated_commands', hosts.merge_migrated_commands(
+    [{name: 'a', hostname: 'a.com', port: 22, host_keys: [], username: '',
+      default_command: '', credential: 'hunter2', totp: '123456'}],
+    [{hostname: 'a.com', port: 22, command: 'htop'}]).payload);
+});
+
+test('roaming_update refuses every secret-bearing form field', function () {
+  for (var i = 0; i < SECRETS.length; i++) {
+    assert.strictEqual(hosts.roaming_update(SECRETS[i], 'leaked'), null,
+                       SECRETS[i] + ' must not roam');
+  }
+});
+```
+
+- [ ] **Step 2: Run the tests**
+
+Run: `node --test tests/js/`
+Expected: PASS, 43 tests. These should pass without any implementation change — the builders construct fresh objects with known keys rather than copying their input, which is exactly the property being pinned. If either test FAILS, stop and report: a builder is copying its input wholesale, which is a real defect rather than a test to adjust.
+
+- [ ] **Step 3: Document how to run the suite**
+
+`README.md` has a `### Development` section ending with a "Run tests:" block that
+covers Python only. Extend that block — do not create a new section:
+
+````markdown
+Run tests:
+
+```bash
+pip install pytest
+python -m pytest tests
+```
+
+Browser client tests require Node 20+ and install nothing:
+
+```bash
+node --test tests/js/
+```
+
+They cover the pure decision logic in `webssh/static/js/user-hosts.js` — host
+payload construction, port validation, settings merging, preference precedence,
+and the legacy command migration. DOM behaviour in `main.js` (tab lifecycle, the
+hostname input/select upgrade, asynchronous save sequencing) is not covered.
+````
+
+- [ ] **Step 4: Final verification**
+
+Run: `node --test tests/js/`
+Expected: PASS, 43 tests.
+
+Run: `npm test`
+Expected: PASS, 43 tests.
+
+Run: `/home/ryan/github/rgregg/webssh/.venv/bin/python -m pytest -q`
+Expected: PASS, 234 passed.
+
+Run: `node --check webssh/static/js/user-hosts.js && node --check webssh/static/js/main.js`
+Expected: no output.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/js/user-hosts.test.js README.md
+git commit -m "test: pin the no-secrets invariant and document the JS suite"
+```
+
+---
+
+## Verification Checklist
+
+Before considering this complete:
+
+- [ ] `node --test tests/js/` passes with 43 tests
+- [ ] `/home/ryan/github/rgregg/webssh/.venv/bin/python -m pytest -q` passes with 234
+- [ ] `package.json` has no `dependencies` and no `devDependencies`
+- [ ] No file under `webssh/static/js/` uses `const`, `let`, arrow functions, or template literals
+- [ ] `webssh/static/js/user-hosts.js` contains no DOM access and no jQuery reference
+- [ ] `user-hosts.js` is loaded before `main.js` in `index.html`
+- [ ] The `docker` CI job lists `js` in its `needs:`
+- [ ] The extraction is behaviour-preserving: every moved function does exactly what it did before

--- a/docs/superpowers/plans/2026-08-01-js-test-coverage.md
+++ b/docs/superpowers/plans/2026-08-01-js-test-coverage.md
@@ -19,7 +19,7 @@
 - **Secrets never leave the client.** No function in the new module may ever emit `credential`, `totp`, `password`, `passphrase`, or `privatekey`. Task 6 enforces this as a property over every builder.
 - **The Python suite must stay green at 234 passed.** Run `/home/ryan/github/rgregg/webssh/.venv/bin/python -m pytest -q` (the venv lives at the ORIGINAL repo path, not the worktree).
 
-**Baseline:** `node --test tests/js/` does not exist yet. `pytest` is green at 234. Verify the Python baseline before starting.
+**Baseline:** `node --test tests/js/*.test.js` does not exist yet. `pytest` is green at 234. Verify the Python baseline before starting.
 
 **A note on why this exists.** Review of the client-side tasks found one Critical and eight Important defects, versus roughly one per server-side task. Every test in this plan traces to a defect that review or browser testing actually found; the table in each task names it. Do not add tests that guard nothing — they cost maintenance and buy no signal.
 
@@ -81,7 +81,7 @@ test('validate_port rejects non-numeric text', function () {
 
 - [ ] **Step 2: Run the test to verify it fails**
 
-Run: `node --test tests/js/`
+Run: `node --test tests/js/*.test.js`
 Expected: FAIL — `Cannot find module '../../webssh/static/js/user-hosts.js'`
 
 - [ ] **Step 3: Create the module**
@@ -130,7 +130,7 @@ Note `parseInt('22abc', 10)` is `22`, matching the current behaviour in `main.js
 
 - [ ] **Step 4: Run the test to verify it passes**
 
-Run: `node --test tests/js/`
+Run: `node --test tests/js/*.test.js`
 Expected: PASS, 4 tests.
 
 - [ ] **Step 5: Add package.json**
@@ -146,7 +146,7 @@ Create `package.json`:
     "node": ">=20"
   },
   "scripts": {
-    "test": "node --test tests/js/"
+    "test": "node --test tests/js/*.test.js"
   }
 }
 ```
@@ -194,14 +194,14 @@ In `.github/workflows/python.yml`, add a `js` job alongside `lint` and `test`:
       - uses: actions/setup-node@v4
         with:
           node-version: "20"
-      - run: node --test tests/js/
+      - run: node --test tests/js/*.test.js
 ```
 
 Then add `js` to the `docker` job's `needs:` list so a JavaScript failure blocks the release exactly as a Python failure does. It currently reads `needs: [lint, test]`; make it `needs: [lint, test, js]`.
 
 - [ ] **Step 9: Verify nothing regressed**
 
-Run: `node --test tests/js/`
+Run: `node --test tests/js/*.test.js`
 Expected: PASS, 4 tests.
 
 Run: `/home/ryan/github/rgregg/webssh/.venv/bin/python -m pytest -q`
@@ -325,7 +325,7 @@ test('build_host_payload returns an empty list for no rows', function () {
 
 - [ ] **Step 2: Run the tests to verify they fail**
 
-Run: `node --test tests/js/`
+Run: `node --test tests/js/*.test.js`
 Expected: FAIL — `hosts.build_host_payload is not a function`
 
 - [ ] **Step 3: Implement it**
@@ -389,7 +389,7 @@ Add to `user-hosts.js` above the `return` block, and add `build_host_payload` to
 
 - [ ] **Step 4: Run the tests to verify they pass**
 
-Run: `node --test tests/js/`
+Run: `node --test tests/js/*.test.js`
 Expected: PASS, 13 tests.
 
 - [ ] **Step 5: Rewrite collect_host_rows to use it**
@@ -426,7 +426,7 @@ The returned shape `{hosts, error}` is unchanged, so the caller needs no edit.
 
 - [ ] **Step 6: Verify nothing regressed**
 
-Run: `node --test tests/js/`
+Run: `node --test tests/js/*.test.js`
 Expected: PASS, 13 tests.
 
 Run: `/home/ryan/github/rgregg/webssh/.venv/bin/python -m pytest -q`
@@ -544,7 +544,7 @@ test('roaming_update drops an unusable port instead of sending it', function () 
 
 - [ ] **Step 2: Run the tests to verify they fail**
 
-Run: `node --test tests/js/`
+Run: `node --test tests/js/*.test.js`
 Expected: FAIL — `hosts.merge_settings is not a function`
 
 - [ ] **Step 3: Implement them**
@@ -608,7 +608,7 @@ Add to `user-hosts.js`, and add `ROAMING_FIELDS`, `merge_settings`, and `roaming
 
 - [ ] **Step 4: Run the tests to verify they pass**
 
-Run: `node --test tests/js/`
+Run: `node --test tests/js/*.test.js`
 Expected: PASS, 22 tests.
 
 - [ ] **Step 5: Use them from main.js**
@@ -646,7 +646,7 @@ The roaming branch of `store_items` becomes:
 
 - [ ] **Step 6: Verify nothing regressed**
 
-Run: `node --test tests/js/`
+Run: `node --test tests/js/*.test.js`
 Expected: PASS, 22 tests.
 
 Run: `/home/ryan/github/rgregg/webssh/.venv/bin/python -m pytest -q`
@@ -748,7 +748,7 @@ test('save_error_text never surfaces server detail on 500', function () {
 
 - [ ] **Step 2: Run the tests to verify they fail**
 
-Run: `node --test tests/js/`
+Run: `node --test tests/js/*.test.js`
 Expected: FAIL — `hosts.resolve_terminal_options is not a function`
 
 - [ ] **Step 3: Implement them**
@@ -789,7 +789,7 @@ Add to `user-hosts.js` and to the returned object:
 
 - [ ] **Step 4: Run the tests to verify they pass**
 
-Run: `node --test tests/js/`
+Run: `node --test tests/js/*.test.js`
 Expected: PASS, 32 tests.
 
 - [ ] **Step 5: Use them from main.js**
@@ -814,7 +814,7 @@ Replace `save_error_text` with a thin adapter that keeps the existing single-arg
 
 - [ ] **Step 6: Verify nothing regressed**
 
-Run: `node --test tests/js/`
+Run: `node --test tests/js/*.test.js`
 Expected: PASS, 32 tests.
 
 Run: `/home/ryan/github/rgregg/webssh/.venv/bin/python -m pytest -q`
@@ -937,7 +937,7 @@ test('merge_migrated_commands reports no change when nothing matches', function 
 
 - [ ] **Step 2: Run the tests to verify they fail**
 
-Run: `node --test tests/js/`
+Run: `node --test tests/js/*.test.js`
 Expected: FAIL — `hosts.parse_command_key is not a function`
 
 - [ ] **Step 3: Implement them**
@@ -995,7 +995,7 @@ Add to `user-hosts.js` and to the returned object:
 
 - [ ] **Step 4: Run the tests to verify they pass**
 
-Run: `node --test tests/js/`
+Run: `node --test tests/js/*.test.js`
 Expected: PASS, 41 tests.
 
 - [ ] **Step 5: Use them from main.js**
@@ -1032,7 +1032,7 @@ Leave every guard around this untouched: the `running` flag, the `.always`, the 
 
 - [ ] **Step 6: Verify nothing regressed**
 
-Run: `node --test tests/js/`
+Run: `node --test tests/js/*.test.js`
 Expected: PASS, 41 tests.
 
 Run: `/home/ryan/github/rgregg/webssh/.venv/bin/python -m pytest -q`
@@ -1114,7 +1114,7 @@ test('roaming_update refuses every secret-bearing form field', function () {
 
 - [ ] **Step 2: Run the tests**
 
-Run: `node --test tests/js/`
+Run: `node --test tests/js/*.test.js`
 Expected: PASS, 43 tests. These should pass without any implementation change — the builders construct fresh objects with known keys rather than copying their input, which is exactly the property being pinned. If either test FAILS, stop and report: a builder is copying its input wholesale, which is a real defect rather than a test to adjust.
 
 - [ ] **Step 3: Document how to run the suite**
@@ -1133,7 +1133,7 @@ python -m pytest tests
 Browser client tests require Node 20+ and install nothing:
 
 ```bash
-node --test tests/js/
+node --test tests/js/*.test.js
 ```
 
 They cover the pure decision logic in `webssh/static/js/user-hosts.js` — host
@@ -1144,7 +1144,7 @@ hostname input/select upgrade, asynchronous save sequencing) is not covered.
 
 - [ ] **Step 4: Final verification**
 
-Run: `node --test tests/js/`
+Run: `node --test tests/js/*.test.js`
 Expected: PASS, 43 tests.
 
 Run: `npm test`
@@ -1169,7 +1169,7 @@ git commit -m "test: pin the no-secrets invariant and document the JS suite"
 
 Before considering this complete:
 
-- [ ] `node --test tests/js/` passes with 43 tests
+- [ ] `node --test tests/js/*.test.js` passes with 43 tests
 - [ ] `/home/ryan/github/rgregg/webssh/.venv/bin/python -m pytest -q` passes with 234
 - [ ] `package.json` has no `dependencies` and no `devDependencies`
 - [ ] No file under `webssh/static/js/` uses `const`, `let`, arrow functions, or template literals

--- a/docs/superpowers/specs/2026-07-27-user-editable-hosts-design.md
+++ b/docs/superpowers/specs/2026-07-27-user-editable-hosts-design.md
@@ -17,7 +17,7 @@ of preferences, both stored on the server so they roam across sessions.
 
 ## Scope
 
-In scope: per-user host records, per-user preferences, a settings page, and the
+In scope: per-user host records, per-user preferences, a settings tab, and the
 server-side storage and API behind them.
 
 Out of scope: administrator editing of `config.yaml` through the web UI, sharing
@@ -43,8 +43,8 @@ The feature is active only when all three conditions hold:
 2. a data directory resolves (`userdatadir`, or `userkeydir` as fallback), and
 3. the request carries a valid username in the configured header.
 
-When inactive, `/settings` returns 404, the APIs return 403, and the settings
-link is not rendered. Behavior for existing deployments is unchanged.
+When inactive, `/settings-pane` returns 404, the APIs return 403, and the gear
+control is not rendered. Behavior for existing deployments is unchanged.
 
 `userdatadir` defaults to `userkeydir` so that a deployment already using
 per-user keys needs no new configuration; the JSON files land in the same
@@ -137,13 +137,36 @@ protection applies, since `xsrf_cookies` is enabled by default.
 
 `PUT` validates every entry before writing anything, so a rejected request leaves
 stored data untouched. Full-list replacement rather than per-host `POST` and
-`DELETE` matches a settings page with a Save button and keeps the server free of
+`DELETE` matches a settings pane with a Save button and keeps the server free of
 any opinion about ordering.
 
-## Settings Page
+## Settings Tab
 
-A new `SettingsHandler` serves `/settings` from a `settings.html` template styled
-with the existing `main.css` tokens. Three tabs:
+Settings open as a tab inside the existing WebSSH tab bar, not as a browser
+navigation. The application already has a tab system, and reusing it means
+opening settings never disturbs a live terminal session.
+
+`tabManager.createTab` gains a `kind` field, `"terminal"` or `"settings"`,
+defaulting to terminal. The existing machinery needs little change: `createTab`
+already builds a generic pane div, and `activateTab` and `closeTab` already guard
+on `tab.term` and `tab.sock` being null, which is exactly the state a settings tab
+is in. Three adjustments:
+
+- `activateTab` branches on `kind === "settings"`: hide the shared connect form,
+  as it does for a connected terminal, but skip the fit-and-focus path and set
+  the page title to "Settings".
+- `closeTab`, when the last tab closes, creates a terminal tab rather than
+  whatever kind was just closed.
+- A settings tab is a singleton. The gear control focuses the existing settings
+  tab if one is open and creates one otherwise.
+
+A new `SettingsHandler` serves `/settings-pane`, a `settings.html` Tornado
+template rendering an HTML *fragment* — no `<html>` or `<body>` wrapper — which
+the client injects into the tab's pane. Keeping the markup in a template matches
+how `index.html` is built and avoids introducing a client-side templating layer.
+The endpoint is internal and not meant to be navigated to directly.
+
+The pane has three sub-sections:
 
 **Hosts.** Administrator hosts first, greyed and badged read-only, then the
 user's editable entries. Each editable row supports add, edit, and delete, with a
@@ -158,10 +181,9 @@ still override stored values, so existing links keep working.
 **Connection.** Default encoding, terminal type, and preferred key source
 (stored or uploaded).
 
-The header link opens the page with `target="_blank"`. A separate page would
-otherwise tear down live terminal sessions on navigation; opening in a new
-browser tab removes that cost. The main page refetches its host list on
-`window.focus` so edits appear without a manual reload.
+Because the pane lives in the same document as the connect form, saving changes
+calls a `refresh_host_list()` function directly. No cross-document coordination,
+no polling, and no reload is needed.
 
 ## Client Changes
 
@@ -169,8 +191,9 @@ In `main.js`, `store_items` / `restore_items` and `store_default_command` /
 `restore_default_command` become thin wrappers over a small `prefs` object. It
 hydrates from a blob that `IndexHandler.get` embeds in the rendered page, which
 avoids an extra round trip before the first connect, and issues debounced `PUT`
-requests to `/api/settings` on change. The settings page, being a separate
-document, uses the `GET` endpoints instead. `localStorage` is retained as the offline fallback, and as
+requests to `/api/settings` on change. The settings pane shares this same
+document and therefore the same `prefs` object; it reads current values from it
+rather than refetching. `localStorage` is retained as the offline fallback, and as
 the sole store when the feature is disabled.
 
 Per-host default commands move from the `command:<hostname>:<port>` keys onto the
@@ -199,7 +222,14 @@ Additions to `tests/test_handler.py`:
 - With `user_hosts: false`, a user-added host is still rejected by the allowlist
 
 Additions to `tests/test_settings.py` for `userdatadir` resolution, including the
-fallback to `userkeydir`.
+fallback to `userkeydir`, and a `test_app.py` case asserting `/settings-pane`
+returns 404 when the feature is off and a fragment when it is on.
+
+The repository has no JavaScript test harness, so the tab behavior is verified
+manually: opening settings while a terminal is connected leaves that session
+alive, the gear focuses rather than duplicates an open settings tab, closing the
+last tab yields a terminal tab, and saving a host updates the connect form's host
+dropdown without a reload.
 
 Note for whoever runs the suite: `settings.py` loads the real
 `~/.ssh/known_hosts`, so a malformed line in a developer's own file fails 53

--- a/docs/superpowers/specs/2026-07-27-user-editable-hosts-design.md
+++ b/docs/superpowers/specs/2026-07-27-user-editable-hosts-design.md
@@ -1,0 +1,206 @@
+# User-Editable Host List and Roaming Settings
+
+**Date:** 2026-07-27
+**Status:** Approved design, pending implementation
+
+## Problem
+
+The host list lives in `config.yaml` and only an administrator with filesystem
+access can change it. A signed-in user cannot add a machine of their own. User
+preferences fare no better: the last-used hostname, username, and per-host
+default command sit in `localStorage`, so they vanish when the user switches
+browsers or machines, and terminal appearance is settable only through URL query
+parameters.
+
+This design lets each authenticated user maintain a private host list and a set
+of preferences, both stored on the server so they roam across sessions.
+
+## Scope
+
+In scope: per-user host records, per-user preferences, a settings page, and the
+server-side storage and API behind them.
+
+Out of scope: administrator editing of `config.yaml` through the web UI, sharing
+host lists between users, and any change to how credentials are handled.
+Passwords, TOTP codes, and key passphrases remain client-side only and are never
+written to server storage.
+
+## Identity and Gating
+
+A user is identified by the `userheader` HTTP header (`X-Authentik-Username` by
+default), the same mechanism that already scopes per-user SSH keys.
+
+Two new configuration keys:
+
+```yaml
+user_hosts: true                          # default false
+userdatadir: /var/lib/webssh/user-data    # optional; defaults to userkeydir
+```
+
+The feature is active only when all three conditions hold:
+
+1. `user_hosts` is true,
+2. a data directory resolves (`userdatadir`, or `userkeydir` as fallback), and
+3. the request carries a valid username in the configured header.
+
+When inactive, `/settings` returns 404, the APIs return 403, and the settings
+link is not rendered. Behavior for existing deployments is unchanged.
+
+`userdatadir` defaults to `userkeydir` so that a deployment already using
+per-user keys needs no new configuration; the JSON files land in the same
+per-user directory as `id_ed25519`.
+
+At startup, enabling `user_hosts` without `trusted_proxies` logs the same
+spoofable-header warning that `userkeydir` already emits.
+
+## Storage
+
+A new module, `webssh/user_data.py`, sits alongside `user_keys.py` and reuses its
+`sanitize_username` and path-traversal guard:
+
+```
+<userdatadir>/<username>/hosts.json
+<userdatadir>/<username>/settings.json
+```
+
+Writes go through `tempfile` plus `os.rename` at mode `0600`, matching the
+atomic-write pattern in `user_keys.py`. Each file carries a `"version": 1` field
+so a later schema change has somewhere to hook. A missing file reads as empty. A
+corrupt or unparseable file is logged and also reads as empty; it never raises to
+the request handler and never blocks a connection.
+
+Public surface:
+
+- `read_hosts(dir, user)` / `write_hosts(dir, user, hosts)`
+- `read_settings(dir, user)` / `write_settings(dir, user, settings)`
+- `validate_hosts(hosts)` / `validate_settings(settings)`, raising `ValueError`
+
+Concurrency is last-write-wins per user. Two browser tabs editing the same user's
+list simultaneously is not a case worth locking for.
+
+## Host Model
+
+A user host record:
+
+```json
+{
+  "name": "homelab",
+  "hostname": "nas.lan",
+  "port": 2222,
+  "host_key": ["ssh-ed25519 AAAA..."],
+  "username": "ryan",
+  "default_command": "tmux attach || tmux new"
+}
+```
+
+`name`, `hostname`, `port`, and `host_key` are validated by the same code path as
+administrator hosts. The per-entry validation currently inside
+`parse_allowed_hosts` is extracted into a shared `parse_host_entry` so a user
+cannot submit a malformed key pin that an administrator could not.
+
+`username` and `default_command` are user-only fields. They prefill the connect
+form when the host is selected and are ignored on administrator entries.
+
+## Allowlist Semantics
+
+`hosts:` in `config.yaml` is a security allowlist, not a bookmark list. Making it
+user-editable would silently dissolve that control, which is why the feature is
+opt-in.
+
+At connect time, `check_allowed_hosts` and `load_configured_host_key` consult the
+administrator hosts merged with the requesting user's hosts. Two rules govern the
+merge:
+
+- Administrator entries win on a `hostname:port` collision, so a user cannot
+  override a pinned production host key.
+- When `user_hosts` is false, only administrator hosts are consulted, and a
+  user-supplied host outside the allowlist is rejected exactly as today.
+
+Personal hosts carry their own `host_key` pin. This is what makes them usable
+under `policy: reject`, where an unpinned host cannot connect at all.
+
+When no administrator allowlist is configured, the hostname field remains
+free-text as it is today, and personal hosts act purely as saved bookmarks.
+
+## API
+
+A new `UserDataHandler` in `webssh/handler.py`, modeled on `UserKeyHandler`: the
+same `get_auth_username()` helper and the same 401 and 400 responses. XSRF
+protection applies, since `xsrf_cookies` is enabled by default.
+
+| Route           | Method | Behavior                                                     |
+| --------------- | ------ | ------------------------------------------------------------ |
+| `/api/hosts`    | GET    | `{admin_hosts: [...], user_hosts: [...]}`, admin entries flagged read-only |
+| `/api/hosts`    | PUT    | Full replacement of the user's list                          |
+| `/api/settings` | GET    | The user's settings object                                   |
+| `/api/settings` | PUT    | Full replacement of the user's settings                      |
+
+`PUT` validates every entry before writing anything, so a rejected request leaves
+stored data untouched. Full-list replacement rather than per-host `POST` and
+`DELETE` matches a settings page with a Save button and keeps the server free of
+any opinion about ordering.
+
+## Settings Page
+
+A new `SettingsHandler` serves `/settings` from a `settings.html` template styled
+with the existing `main.css` tokens. Three tabs:
+
+**Hosts.** Administrator hosts first, greyed and badged read-only, then the
+user's editable entries. Each editable row supports add, edit, and delete, with a
+textarea for host key pins and a hint pointing at
+`ssh-keyscan -t ed25519,rsa <hostname>`.
+
+**Terminal.** Font size, background color, foreground color, cursor color, and
+cursor blink. These exist today only as the URL parameters `fontsize`, `bgcolor`,
+`fontcolor`, and `cursor`; the page becomes their persistent home. URL parameters
+still override stored values, so existing links keep working.
+
+**Connection.** Default encoding, terminal type, and preferred key source
+(stored or uploaded).
+
+The header link opens the page with `target="_blank"`. A separate page would
+otherwise tear down live terminal sessions on navigation; opening in a new
+browser tab removes that cost. The main page refetches its host list on
+`window.focus` so edits appear without a manual reload.
+
+## Client Changes
+
+In `main.js`, `store_items` / `restore_items` and `store_default_command` /
+`restore_default_command` become thin wrappers over a small `prefs` object. It
+hydrates from a blob that `IndexHandler.get` embeds in the rendered page, which
+avoids an extra round trip before the first connect, and issues debounced `PUT`
+requests to `/api/settings` on change. The settings page, being a separate
+document, uses the `GET` endpoints instead. `localStorage` is retained as the offline fallback, and as
+the sole store when the feature is disabled.
+
+Per-host default commands move from the `command:<hostname>:<port>` keys onto the
+host record's `default_command`. A one-time client-side migration copies any
+existing `localStorage` values onto matching host records on first load.
+
+Credentials, TOTP codes, and passphrases are excluded from the `prefs` object and
+are never transmitted to the settings API.
+
+## Testing
+
+`tests/test_user_data.py`, in the style of `test_user_keys.py`:
+
+- Round-trip read and write for hosts and settings
+- Atomic write leaves no partial file on failure
+- Missing file and corrupt file both read as empty without raising
+- Path traversal via `../` in a username is rejected
+- `validate_hosts` rejects malformed ports, missing hostnames, and bad key pins
+
+Additions to `tests/test_handler.py`:
+
+- 403 when the feature is disabled, 401 when the header is absent
+- XSRF rejection on `PUT`
+- `PUT` with an invalid entry returns 400 and leaves stored data unchanged
+- A user host cannot override an administrator host key pin
+- With `user_hosts: false`, a user-added host is still rejected by the allowlist
+
+Additions to `tests/test_settings.py` for `userdatadir` resolution, including the
+fallback to `userkeydir`.
+
+Note for whoever runs the suite: `settings.py` loads the real
+`~/.ssh/known_hosts`, so a malformed line in a developer's own file fails 53
+unrelated tests. This is an environment issue, not a regression.

--- a/docs/superpowers/specs/2026-07-27-user-editable-hosts-followups.md
+++ b/docs/superpowers/specs/2026-07-27-user-editable-hosts-followups.md
@@ -94,6 +94,39 @@ store — was fixed in `e1b184f` and is covered by tests.
   harness would be the single largest durable improvement to this feature's
   safety net.
 
+## Lint modernisation backlog
+
+CI's `lint` job installed `ruff` unpinned, so the 0.16 release turned the gate
+red across the whole repository without any code change — 250 errors on `main`,
+308 on the user-hosts branch. The job is now pinned to `ruff==0.15.6`, the last
+version under which the repository is clean. Upgrading the pin is worth doing,
+but it is a deliberate piece of work rather than a version bump:
+
+- **`UP032`** (88) — `.format()` calls that ruff wants as f-strings.
+- **`LOG015`** (63) — `logging.info()` and friends on the root logger. The whole
+  codebase does this; there are 61 such calls in `webssh/` alone.
+- **`UP025`** (27) — `u''` prefixes.
+- **`I001`** (25) — import blocks in the repository's compact parenthesised
+  style rather than ruff's one-per-line isort profile.
+- **`UP008`** (14) — `super(ClassName, self)` rather than bare `super()`.
+- **`UP004`** (9) — explicit `object` inheritance.
+
+Two cautions for whoever does it:
+
+- **`TRY004` must not be auto-fixed.** It wants `TypeError` where
+  `user_data.validate_hosts` and `validate_settings` raise `ValueError` for a
+  malformed payload. `handler.py` catches `ValueError` at five sites to return
+  400; raising `TypeError` would turn a bad request into an unhandled 500 and
+  break twelve tests. The current behaviour is correct.
+- Fix the whole repository in one pass or not at all. Modernising individual
+  files leaves them stylistically inconsistent with the modules they mirror —
+  `user_data.py` was written to match `user_keys.py`, and `test_user_data.py` to
+  match `test_user_keys.py`, down to the import formatting.
+
+Note that the plans and specs under `docs/superpowers/` mandate the current
+style as an explicit constraint. If the codebase modernises, that guidance
+becomes stale and should be updated or marked historical.
+
 ## Cosmetic
 
 - The administrator and user host tables have different column counts, so their

--- a/docs/superpowers/specs/2026-07-27-user-editable-hosts-followups.md
+++ b/docs/superpowers/specs/2026-07-27-user-editable-hosts-followups.md
@@ -1,0 +1,107 @@
+# User-Editable Hosts — Deferred Follow-Ups
+
+Findings raised during review of the user-editable-hosts branch that were
+deliberately deferred rather than fixed before merge. None blocks merge. They are
+recorded here so the judgement is available later; delete this file once it has
+been triaged.
+
+Items fixed before merge are not listed. The security defect found by the final
+whole-branch review — user host key pins leaking into a process-global paramiko
+store — was fixed in `e1b184f` and is covered by tests.
+
+## Correctness
+
+- **Duplicate `known_hosts` appends under `autoadd` + `user_hosts`.** Each request
+  now starts from the startup host-key snapshot, so repeat connections to a host
+  absent from it re-append an identical line, growing the file unboundedly on a
+  busy deployment. Paramiko de-duplicates on load, and this is the security-safe
+  direction, so it is cosmetic. Note that `autoadd` plus `user_hosts` is not the
+  documented recommendation — the docs recommend `reject` with pinned keys.
+- **Quarantine exhaustion.** After 20 `.corrupt` files accumulate for one user,
+  `quarantine_file` gives up and leaves the unreadable file in place, which
+  re-opens the data-loss path it exists to prevent. Requires 21 separate
+  corruption events on one account, each logged at error level.
+- **`get_effective_hosts` is called twice per connect POST**, re-reading and
+  re-parsing `hosts.json` synchronously on the IOLoop thread. Memoize per request.
+- **Non-`ValueError` failures from `_write_json`** (for example `OSError` from
+  `os.rename`) propagate as an uncaught 500 through Tornado's default handling.
+  No path leak, but the client sees no useful message.
+- **`os.write` return value is ignored** in `_write_json`. Regular-file writes do
+  not short-write in practice; `os.fdopen`/`f.write` would be more correct.
+- **Hostname collision matching is exact-string**, with no case folding. Reviewed
+  and judged *not* an invariant break: a user can already add the same machine
+  under a different name with their own pin, so case-folding buys nothing.
+- **`check_feature_enabled`'s `not self.user_data_dir` clause is dead** as wired,
+  since `user_hosts_enabled` already ANDs the directory in.
+
+## Client behaviour
+
+- **`refresh_host_list`'s `$.get` has no `.fail` handler.** On failure the
+  hostname field keeps its last known-good state — coherent, but silently stale.
+- **A failed `/settings-pane` fetch is permanent.** The tab shows "Failed to load
+  settings" and the gear re-focuses that dead tab; only closing it allows a retry.
+- **Rows with a blank hostname are silently dropped on save**, with no feedback to
+  the user that their half-filled row vanished.
+- **A non-numeric port typo is indistinguishable from blank.** `input type=number`
+  sanitises `"abc"` to `""`, so it silently defaults to 22. Out-of-range and
+  zero/negative values *are* correctly blocked. Detecting the rest needs
+  `validity.badInput`.
+- **`connect()` from the settings tab creates the terminal tab before form
+  validation**, so a connect that then fails validation leaves an empty
+  "New Connection" tab behind.
+- **`refresh_host_list` side effects.** `trigger('change')` mutates the connect
+  form; a stale `current` value can select a different host.
+- **`get_xsrf_token` reads the cookie with a regex**, which is more fragile than
+  the existing `$('input[name="_xsrf"]').val()` idiom already used elsewhere in
+  `main.js`.
+- **Residual narrow race in preference flushing.** A connect that arms a new flush
+  while the settings pane's PUTs are in flight can be stomped by the pane's
+  response rebind. Window is a few hundred milliseconds.
+- **`prefs.schedule` arms a pointless 1s timer per connect** when the feature is
+  disabled; `flush` then early-returns.
+- **`key_source: 'stored'` is applied without checking `has_stored_key`**, and the
+  `'upload'` direction is not restored, so a stale preference can produce a
+  confusing connect failure.
+- **IPv6 hosts do not migrate.** The legacy `command:<host>:<port>` localStorage
+  key is split on `:`. Nothing is corrupted; the command simply does not carry
+  over. This is a pre-existing key-format limitation.
+- **`{% raw json_encode(user_settings) %}`**: Tornado blocks `</script>`
+  breakout, but a `<!--<script>` sequence in a stored string can still confuse the
+  HTML script-data parser. Self-only — the attacker is the victim.
+- **Stored `cursor` beats URL `fontcolor`** as a fallback. Defensible, and as
+  specified, but worth knowing.
+
+## Tests
+
+- **`_restore_options` restores 3 of 10 mutated tornado globals**, to hardcoded
+  values rather than saved originals. Safe only because every other `get_app` in
+  the suite sets those options itself — that is execution-order luck, not
+  construction. The suite is the only automated guard on the security invariants,
+  so this is the highest-value item in this section.
+- **A new test class leaves `options.policy = 'reject'` behind** on cleanup. Same
+  class of problem; group the fix with the item above.
+- **Tests leak one `tempfile.mkdtemp` per test method** (about a dozen per run)
+  with no cleanup.
+- **Coverage gaps**: PUT while the feature is disabled, XSRF on `/api/settings`,
+  405 on unsupported verbs, and `admin_hosts` contents are never asserted.
+- **Corrupt/wrong-shape read tests cover `hosts.json` only**, not `settings.json`,
+  though both share `_read_json`.
+- **No dedicated test for the non-numeric-port `ValueError` path**, which was the
+  one sanctioned behaviour change in the initial refactor.
+- **No JavaScript test harness exists in this repository.** A large fraction of
+  this feature is client-side and therefore has no automated coverage; it was
+  verified by code review plus three scripted browser passes. Introducing a JS
+  harness would be the single largest durable improvement to this feature's
+  safety net.
+
+## Cosmetic
+
+- The administrator and user host tables have different column counts, so their
+  columns do not line up vertically. Fixing it needs template restructuring.
+- `get_user_data_dir` lets an `OSError` from `realpath` escape as `OSError`
+  rather than the documented `ValueError`. Inherited from `user_keys.py`.
+- `apply_config_settings` cannot distinguish a config-supplied `false` from the
+  default `false`. Pre-existing pattern; harmless for the current keys.
+- The "enabled but unconfigured" warning arguably belongs in
+  `settings.check_user_data_dir`, which already owns the empty-directory
+  decision; it is now checked in two places.

--- a/docs/superpowers/specs/2026-07-27-user-editable-hosts-followups.md
+++ b/docs/superpowers/specs/2026-07-27-user-editable-hosts-followups.md
@@ -73,13 +73,17 @@ store — was fixed in `e1b184f` and is covered by tests.
 
 ## Tests
 
-- **`_restore_options` restores 3 of 10 mutated tornado globals**, to hardcoded
-  values rather than saved originals. Safe only because every other `get_app` in
-  the suite sets those options itself — that is execution-order luck, not
-  construction. The suite is the only automated guard on the security invariants,
-  so this is the highest-value item in this section.
-- **A new test class leaves `options.policy = 'reject'` behind** on cleanup. Same
-  class of problem; group the fix with the item above.
+- ~~**`_restore_options` restores 3 of 10 mutated tornado globals**, to hardcoded
+  values rather than saved originals.~~ Fixed. `OptionsRestoreMixin.override_options`
+  snapshots the previous value of every option a test overrides and restores
+  exactly that. `TestSuiteLeavesOptionsClean` pins the invariant; it failed
+  against the old code with `policy: ('warning', 'reject')`.
+- ~~**A new test class leaves `options.policy = 'reject'` behind** on cleanup.~~
+  Fixed with the item above.
+- **`OtherTestBase` still restores nothing at all.** It mutates eight globals and
+  puts none of them back, so the rest of the suite continues to pass by
+  execution-order luck rather than construction. `override_options` is now
+  available to it; converting it is the remaining half of this item.
 - **Tests leak one `tempfile.mkdtemp` per test method** (about a dozen per run)
   with no cleanup.
 - **Coverage gaps**: PUT while the feature is disabled, XSRF on `/api/settings`,

--- a/docs/superpowers/specs/2026-07-31-js-test-coverage-design.md
+++ b/docs/superpowers/specs/2026-07-31-js-test-coverage-design.md
@@ -66,10 +66,10 @@ Eight functions move, grouped below by the call site they come from:
 
 | Function | Replaces logic now in |
 | --- | --- |
-| `validate_port(text)` → `{port}`, `{omit: true}`, or `{error}` | the port branch of `collect_host_rows` |
+| `validate_port(text)` → `{port}`, `{omit: true}`, or `{invalid: true}` | the port branch of `collect_host_rows` |
 | `build_host_payload(rows)` → `{hosts}` or `{error}` | the row-to-payload mapping in `collect_host_rows` |
 | `merge_settings(current, ui)` | the roaming carry-forward in `collect_settings` |
-| `roaming_from_form(names, values)` | the `ROAMING_FIELDS` mapping in `store_items` |
+| `roaming_update(name, value)` | the `ROAMING_FIELDS` mapping in `store_items` |
 | `resolve_terminal_options(url_opts, stored)` | the `termOptions` precedence chain |
 | `parse_command_key(key)` and `merge_migrated_commands(hosts, found)` | `migrate_local_commands` |
 | `save_error_text(status, body)` | `save_error_text`, already nearly pure |
@@ -81,10 +81,11 @@ be unchanged.
 
 ## Harness
 
-`node --test tests/js/`, built into Node 20. A `package.json` exists only to
-declare the test script and the Node version floor; it has no `dependencies` and
-no `devDependencies`, so there is nothing to install and no lockfile to maintain
-in a repository that is otherwise pure Python.
+`node --test tests/js/*.test.js`, built into Node 20. A `package.json` exists
+only to declare the test script and the Node version floor (`engines.node:
+">=20"`); it has no `dependencies` and no `devDependencies`, so there is
+nothing to install and no lockfile to maintain in a repository that is
+otherwise pure Python.
 
 ## Coverage
 
@@ -108,22 +109,33 @@ than needing a new test.
 
 ## CI
 
-A new job in `.github/workflows/python.yml`, parallel to `lint` and `test`:
+A new job in `.github/workflows/python.yml`, parallel to `lint` and `test`,
+matrixed over Node versions the same way the Python job is matrixed over
+Python versions:
 
 ```yaml
   js:
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: ["20", "22", "24"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: "20"
-      - run: node --test tests/js/
+          node-version: ${{ matrix.node-version }}
+      # `ls` fails loudly if the glob matches nothing (e.g. a test file
+      # renamed off *.test.js or moved into a subdirectory), so the gate
+      # cannot pass vacuously. The glob is non-recursive; a future
+      # tests/js/<subdir>/*.test.js needs this pattern updated.
+      - run: ls tests/js/*.test.js && node --test tests/js/*.test.js
 ```
 
-The `docker` job's `needs:` list gains `js`, so a JavaScript failure blocks the
-release exactly as a Python failure does. Expected runtime is a few seconds:
-there is no browser to download and nothing to install.
+The `docker` job's `needs:` list gains `js`, so a JavaScript failure on any
+matrixed Node version blocks the release exactly as a Python failure does.
+Expected runtime is a few seconds: there is no browser to download and
+nothing to install.
 
 ## Out of Scope
 

--- a/docs/superpowers/specs/2026-07-31-js-test-coverage-design.md
+++ b/docs/superpowers/specs/2026-07-31-js-test-coverage-design.md
@@ -1,0 +1,156 @@
+# JavaScript Test Coverage for the User-Hosts Client
+
+**Date:** 2026-07-31
+**Status:** Approved design, pending implementation
+
+## Problem
+
+The user-editable-hosts feature added roughly a thousand lines of client-side
+JavaScript with no automated coverage. The repository has no JavaScript test
+harness at all, so `webssh/static/js/main.js` is guarded only by code review and
+by scripted browser passes run by hand.
+
+That gap is not theoretical. Review of the client-side tasks found one Critical
+and eight Important defects, against roughly one finding per server-side task,
+and two further defects surfaced only when the application was driven in a real
+browser. Several were silent-data-loss bugs: a save issued before the host list
+loaded wiped every stored host, and every settings save erased the roamed
+last-used values.
+
+`main.js` is 2071 lines inside a single `jQuery(function ($) { ... })` closure
+that exports nothing, so none of that logic is reachable from a test.
+
+## Goal
+
+A CI regression gate. The tests run in GitHub Actions on every pull request,
+alongside the existing Python matrix, and a failure blocks the release job the
+same way a pytest failure does.
+
+## Approach
+
+Decision logic moves out of `main.js` into a new module; DOM reading stays
+behind. `main.js` reads the settings pane into plain values and passes them to
+the module, which decides what to do with them.
+
+This keeps the extracted surface genuinely pure, which in turn means the tests
+need **no dependencies at all** — no jsdom, no jQuery, no npm packages. Node's
+built-in `node --test` runner is the whole harness.
+
+The alternative approaches were considered and rejected. Loading `main.js` into
+jsdom avoids a refactor but requires stubbing xterm, WebSocket, and FormData
+before the file will even load, and couples every test to DOM structure.
+Committing the Playwright drivers gives the highest fidelity but needs a Chromium
+download and a running Tornado server in CI, making it the slowest and flakiest
+tier for a per-pull-request gate.
+
+## The Module
+
+`webssh/static/js/user-hosts.js`, using the ES5 global-with-CommonJS-guard
+pattern so the browser gets a global and Node gets a `require`-able module:
+
+```js
+var webssh_hosts = (function () {
+  // pure functions
+  return { validate_port: validate_port, /* ... */ };
+}());
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = webssh_hosts;
+}
+```
+
+It loads from a `<script>` tag in `index.html` placed before `main.js`. It has no
+dependency on jQuery and touches no globals other than its own.
+
+Eight functions move, grouped below by the call site they come from:
+
+| Function | Replaces logic now in |
+| --- | --- |
+| `validate_port(text)` → `{port}`, `{omit: true}`, or `{error}` | the port branch of `collect_host_rows` |
+| `build_host_payload(rows)` → `{hosts}` or `{error}` | the row-to-payload mapping in `collect_host_rows` |
+| `merge_settings(current, ui)` | the roaming carry-forward in `collect_settings` |
+| `roaming_from_form(names, values)` | the `ROAMING_FIELDS` mapping in `store_items` |
+| `resolve_terminal_options(url_opts, stored)` | the `termOptions` precedence chain |
+| `parse_command_key(key)` and `merge_migrated_commands(hosts, found)` | `migrate_local_commands` |
+| `save_error_text(status, body)` | `save_error_text`, already nearly pure |
+
+The extraction must be behaviour-preserving. Each moved function keeps its
+current semantics exactly; this is a refactor plus tests, not a redesign. The
+Python suite and the browser behaviour verified during the feature's review must
+be unchanged.
+
+## Harness
+
+`node --test tests/js/`, built into Node 20. A `package.json` exists only to
+declare the test script and the Node version floor; it has no `dependencies` and
+no `devDependencies`, so there is nothing to install and no lockfile to maintain
+in a repository that is otherwise pure Python.
+
+## Coverage
+
+Every test traces to a defect that review or browser testing actually found.
+Tests that do not guard a known failure mode are not worth their maintenance.
+
+| Test | Defect it guards |
+| --- | --- |
+| Blank port omits the key; `99999`, `0`, `-5` return an error; `22` passes | A typo'd port was silently rewritten to 22, routing around server validation |
+| Payload emits `host_key` singular; reads `host_keys` plural | A direction mismatch would silently drop pinned host keys |
+| Rows with a blank hostname are skipped, not emitted as malformed | Half-filled rows reaching the server as invalid entries |
+| `merge_settings` carries `last_hostname`, `last_username`, `last_port` forward | Every settings save wiped the roamed values, defeating roaming on a second machine |
+| No builder output ever contains `credential`, `totp`, `password`, or `passphrase` | The security invariant that secrets never reach the server |
+| URL parameter beats stored value beats built-in default | A stored preference silently overriding an explicit URL parameter |
+| Migration preserves every field of every host and never fabricates one | The migration rewrites the whole host list; a dropped field destroys pinned keys |
+| A 400 surfaces the server's message; a 500 does not | Server-state detail, including filesystem paths, leaking to clients |
+
+The secrets test is written as a property over all builder outputs rather than a
+single case, so a future field added to a payload is covered by default rather
+than needing a new test.
+
+## CI
+
+A new job in `.github/workflows/python.yml`, parallel to `lint` and `test`:
+
+```yaml
+  js:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - run: node --test tests/js/
+```
+
+The `docker` job's `needs:` list gains `js`, so a JavaScript failure blocks the
+release exactly as a Python failure does. Expected runtime is a few seconds:
+there is no browser to download and nothing to install.
+
+## Out of Scope
+
+This design deliberately does not cover, and the resulting suite must not be
+described as covering:
+
+- The hostname field's input-to-select upgrade and its reverse.
+- Tab lifecycle: opening, focusing, closing, and the last-tab fallback.
+- The debounced settings flush and other asynchronous save sequencing.
+- XSS safety of DOM construction.
+- The guard preventing a save from clearing hosts before the list has loaded.
+  This was the Critical defect found in review. Making it unit-testable would
+  mean threading a `loaded` flag through `build_host_payload`, which was
+  considered and rejected as not worth changing a shipped signature. The
+  protection remains where it is today, in the Save button's disabled state,
+  covered by code review and by browser verification.
+
+These remain verified by review and by manual browser passes. A future
+Playwright suite would close them; it is out of scope here because a
+browser-dependent job is the wrong shape for a per-pull-request gate.
+
+## Delivery
+
+The work extends the existing `worktree-user-editable-hosts` branch and pull
+request #29, so the feature and its tests land together.
+
+This re-opens a diff that has already passed a full review pass, including a
+security fix. The mitigation is that the extraction is behaviour-preserving and
+mechanical, and the resulting diff gets its own review focused on that property:
+for each moved function, does the moved code do exactly what the original did?

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "webssh-client-tests",
+  "private": true,
+  "description": "Unit tests for the WebSSH browser client. No runtime dependencies.",
+  "engines": {
+    "node": ">=20"
+  },
+  "scripts": {
+    "test": "node --test tests/js/"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -6,6 +6,6 @@
     "node": ">=20"
   },
   "scripts": {
-    "test": "node --test tests/js/"
+    "test": "node --test tests/js/*.test.js"
   }
 }

--- a/tests/js/user-hosts.test.js
+++ b/tests/js/user-hosts.test.js
@@ -372,13 +372,39 @@ test('merge_migrated_commands reports no change when nothing matches', function 
   assert.deepStrictEqual(out.payload, []);
 });
 
-var SECRETS = ['credential', 'totp', 'password', 'passphrase', 'privatekey'];
+// This property covers every builder that takes an object-shaped input and
+// constructs its output by explicit key access: build_host_payload,
+// merge_settings, merge_migrated_commands, resolve_terminal_options, and
+// save_error_text. validate_port and parse_command_key take plain strings,
+// not objects, so they are out of scope by construction.
+//
+// It checks two independent things: that none of the secret KEY NAMES
+// appear in the stringified output (catching a wholesale copy of the input,
+// e.g. a `for...in` spread), and that none of the poisoned sentinel VALUES
+// appear either (catching a rename leak, e.g. `settings.saved_cred =
+// current.credential`, where the key name never shows up but the value
+// still ships). Passing both halves is required; passing only the key-name
+// half would miss a leak that forwards a secret's value under an innocuous
+// key. Sentinel values (not realistic-looking secrets like 'hunter2') are
+// used so a legitimate fixture string can never collide with the check.
+var SECRET_KEYS = ['credential', 'totp', 'password', 'passphrase', 'privatekey'];
+var SECRET_VALUES = [
+  'SEKRIT-credential-value', 'SEKRIT-totp-value', 'SEKRIT-password-value',
+  'SEKRIT-passphrase-value', 'SEKRIT-privatekey-value'
+];
 
 function assert_no_secrets(label, value) {
   var text = JSON.stringify(value);
-  for (var i = 0; i < SECRETS.length; i++) {
-    assert.ok(text.indexOf(SECRETS[i]) === -1,
-              label + ' must never carry ' + SECRETS[i] + ', got: ' + text);
+  var i;
+  for (i = 0; i < SECRET_KEYS.length; i++) {
+    assert.ok(text.indexOf(SECRET_KEYS[i]) === -1,
+              label + ' must never carry the key "' + SECRET_KEYS[i] +
+              '", got: ' + text);
+  }
+  for (i = 0; i < SECRET_VALUES.length; i++) {
+    assert.ok(text.indexOf(SECRET_VALUES[i]) === -1,
+              label + ' must never carry the value "' + SECRET_VALUES[i] +
+              '", got: ' + text);
   }
 }
 
@@ -388,33 +414,54 @@ test('no builder output can carry a secret field', function () {
   var poisoned = {
     name: 'a', hostname: 'a.com', port_text: '22', keys_text: '',
     username: 'u', default_command: 'cmd',
-    credential: 'hunter2', totp: '123456', password: 'p',
-    passphrase: 'pp', privatekey: 'pk'
+    credential: SECRET_VALUES[0], totp: SECRET_VALUES[1],
+    password: SECRET_VALUES[2], passphrase: SECRET_VALUES[3],
+    privatekey: SECRET_VALUES[4]
   };
   assert_no_secrets('build_host_payload',
                     hosts.build_host_payload([poisoned]).hosts);
 
   var poisoned_current = {
-    last_hostname: 'nas.lan', credential: 'hunter2', totp: '123456',
-    password: 'p', passphrase: 'pp', privatekey: 'pk'
+    last_hostname: 'nas.lan', credential: SECRET_VALUES[0], totp: SECRET_VALUES[1],
+    password: SECRET_VALUES[2], passphrase: SECRET_VALUES[3],
+    privatekey: SECRET_VALUES[4]
   };
   var poisoned_ui = {
     font_size_text: '14', background: '', foreground: '', cursor: '',
     encoding: '', term: '', cursor_blink: true, key_source: 'upload',
-    credential: 'hunter2', totp: '123456'
+    credential: SECRET_VALUES[0], totp: SECRET_VALUES[1]
   };
   assert_no_secrets('merge_settings',
                     hosts.merge_settings(poisoned_current, poisoned_ui));
 
   assert_no_secrets('merge_migrated_commands', hosts.merge_migrated_commands(
     [{name: 'a', hostname: 'a.com', port: 22, host_keys: [], username: '',
-      default_command: '', credential: 'hunter2', totp: '123456'}],
+      default_command: '', credential: SECRET_VALUES[0], totp: SECRET_VALUES[1]}],
     [{hostname: 'a.com', port: 22, command: 'htop'}]).payload);
+
+  var poisoned_stored = {
+    cursor_blink: true, background: '', foreground: '', cursor: '',
+    font_size: '14',
+    credential: SECRET_VALUES[0], totp: SECRET_VALUES[1],
+    password: SECRET_VALUES[2], passphrase: SECRET_VALUES[3],
+    privatekey: SECRET_VALUES[4]
+  };
+  assert_no_secrets('resolve_terminal_options',
+                    hosts.resolve_terminal_options({}, poisoned_stored));
+
+  var poisoned_body = {
+    error: 'Rejected: check hostnames, ports, and host keys.',
+    credential: SECRET_VALUES[0], totp: SECRET_VALUES[1],
+    password: SECRET_VALUES[2], passphrase: SECRET_VALUES[3],
+    privatekey: SECRET_VALUES[4]
+  };
+  assert_no_secrets('save_error_text', hosts.save_error_text(400, poisoned_body));
+  assert_no_secrets('save_error_text', hosts.save_error_text(500, poisoned_body));
 });
 
 test('roaming_update refuses every secret-bearing form field', function () {
-  for (var i = 0; i < SECRETS.length; i++) {
-    assert.strictEqual(hosts.roaming_update(SECRETS[i], 'leaked'), null,
-                       SECRETS[i] + ' must not roam');
+  for (var i = 0; i < SECRET_KEYS.length; i++) {
+    assert.strictEqual(hosts.roaming_update(SECRET_KEYS[i], 'leaked'), null,
+                       SECRET_KEYS[i] + ' must not roam');
   }
 });

--- a/tests/js/user-hosts.test.js
+++ b/tests/js/user-hosts.test.js
@@ -465,3 +465,37 @@ test('roaming_update refuses every secret-bearing form field', function () {
                        SECRET_KEYS[i] + ' must not roam');
   }
 });
+
+// Seam test: collect_host_rows in main.js builds a plain object per DOM row
+// using literal keys (name, hostname, port_text, keys_text, username,
+// default_command), and build_host_payload here reads those same literal
+// keys back off the object. Nothing but this shared spelling connects the
+// two files -- a module boundary, not a shared type -- so a one-character
+// typo on either side (e.g. keys_text -> key_text in main.js) compiles
+// cleanly, every existing unit test here still passes (they exercise this
+// module in isolation and construct rows using the *correct* key names),
+// and the bug only shows up in the browser: r.keys_text becomes undefined,
+// split_keys('') returns [], and every host in the next Save silently ships
+// with host_key: [], wiping the user's pinned host keys.
+//
+// A pure unit test cannot see main.js's DOM-reading code at all, so this
+// test reads main.js as plain text (fs is a Node builtin; that is allowed
+// in a TEST file, just not inside the module) and asserts every key
+// user-hosts.js declares it depends on is still spelled out somewhere in
+// main.js. This is a deliberately narrow, low-fidelity check -- it would
+// not catch every possible bug at this seam -- but it directly catches the
+// silent-data-loss typo class above, which unit tests structurally cannot.
+test('HOST_ROW_KEYS stay in sync with main.js collect_host_rows', function () {
+  var fs = require('node:fs');
+  var path = require('node:path');
+  var main_js = fs.readFileSync(
+    path.join(__dirname, '../../webssh/static/js/main.js'), 'utf8');
+
+  assert.ok(hosts.HOST_ROW_KEYS.length > 0, 'HOST_ROW_KEYS must not be empty');
+  for (var i = 0; i < hosts.HOST_ROW_KEYS.length; i++) {
+    var key = hosts.HOST_ROW_KEYS[i];
+    assert.ok(main_js.indexOf(key) !== -1,
+              'main.js no longer references row key "' + key + '"; ' +
+              'collect_host_rows and build_host_payload have drifted apart');
+  }
+});

--- a/tests/js/user-hosts.test.js
+++ b/tests/js/user-hosts.test.js
@@ -35,3 +35,88 @@ test('validate_port preserves parseInt leniency for a numeric prefix', function 
   // extraction must not tighten behaviour. Not a bug to "fix".
   assert.deepStrictEqual(hosts.validate_port('22abc'), {port: 22});
 });
+
+function row(over) {
+  var base = {name: '', hostname: '', port_text: '', keys_text: '',
+              username: '', default_command: ''};
+  for (var k in over) { base[k] = over[k]; }
+  return base;
+}
+
+test('build_host_payload maps a full row and trims every field', function () {
+  var out = hosts.build_host_payload([row({
+    name: '  homelab ', hostname: ' nas.lan ', port_text: '2222',
+    keys_text: ' ssh-ed25519 AAAA ', username: ' ryan ',
+    default_command: ' tmux attach '
+  })]);
+  assert.strictEqual(out.error, null);
+  assert.deepStrictEqual(out.hosts, [{
+    name: 'homelab', hostname: 'nas.lan', host_key: ['ssh-ed25519 AAAA'],
+    username: 'ryan', default_command: 'tmux attach', port: 2222
+  }]);
+});
+
+test('build_host_payload emits host_key singular, never host_keys', function () {
+  // The server consumes host_key and returns host_keys. Sending the wrong
+  // one silently drops the user's pinned keys, which downgrades the host to
+  // the global policy.
+  var out = hosts.build_host_payload([row({
+    hostname: 'a.com', keys_text: 'ssh-ed25519 AAAA'
+  })]);
+  assert.ok('host_key' in out.hosts[0]);
+  assert.ok(!('host_keys' in out.hosts[0]));
+});
+
+test('build_host_payload splits multiple keys and drops blank lines', function () {
+  var out = hosts.build_host_payload([row({
+    hostname: 'a.com', keys_text: 'ssh-ed25519 AAA\n\n  \nssh-rsa BBB\n'
+  })]);
+  assert.deepStrictEqual(out.hosts[0].host_key, ['ssh-ed25519 AAA', 'ssh-rsa BBB']);
+});
+
+test('build_host_payload defaults an empty name to the hostname', function () {
+  var out = hosts.build_host_payload([row({hostname: 'nas.lan'})]);
+  assert.strictEqual(out.hosts[0].name, 'nas.lan');
+});
+
+test('build_host_payload omits port entirely when blank', function () {
+  var out = hosts.build_host_payload([row({hostname: 'a.com'})]);
+  assert.ok(!('port' in out.hosts[0]),
+            'a blank port must be absent, not null/0/NaN, so the server defaults it');
+});
+
+test('build_host_payload skips rows with a blank hostname', function () {
+  var out = hosts.build_host_payload([
+    row({hostname: 'a.com'}),
+    row({name: 'half-filled', keys_text: 'ssh-ed25519 AAA'}),
+    row({hostname: 'b.com'})
+  ]);
+  assert.strictEqual(out.hosts.length, 2);
+  assert.deepStrictEqual([out.hosts[0].hostname, out.hosts[1].hostname],
+                         ['a.com', 'b.com']);
+});
+
+test('build_host_payload reports an invalid port with the offending row index', function () {
+  var out = hosts.build_host_payload([
+    row({hostname: 'a.com'}),
+    row({name: 'db', hostname: 'b.com', port_text: '99999'})
+  ]);
+  assert.strictEqual(out.error,
+    'Invalid port "99999" for host "db" (must be 1-65535).');
+  assert.strictEqual(out.error_index, 1);
+});
+
+test('build_host_payload stops at the first invalid row', function () {
+  var out = hosts.build_host_payload([
+    row({hostname: 'a.com', port_text: '0'}),
+    row({hostname: 'b.com', port_text: '70000'})
+  ]);
+  assert.strictEqual(out.error_index, 0);
+});
+
+test('build_host_payload returns an empty list for no rows', function () {
+  // An explicit empty list is a legitimate "clear my hosts", distinct from
+  // a failure, and the server honours it as such.
+  assert.deepStrictEqual(hosts.build_host_payload([]),
+                         {hosts: [], error: null, error_index: -1});
+});

--- a/tests/js/user-hosts.test.js
+++ b/tests/js/user-hosts.test.js
@@ -254,6 +254,22 @@ test('resolve_terminal_options falls back through fontcolor for the cursor', fun
   assert.strictEqual(out.theme.cursor, 'lime');
 });
 
+test('resolve_terminal_options prefers a URL cursor over a stored cursor', function () {
+  var out = hosts.resolve_terminal_options(
+    {cursor: 'red'}, {cursor: 'blue', foreground: 'green'});
+  assert.strictEqual(out.theme.cursor, 'red');
+});
+
+test('resolve_terminal_options prefers a stored cursor over URL fontcolor', function () {
+  // The chain is url cursor -> stored cursor -> url fontcolor ->
+  // stored foreground -> 'white'. The ordering looks arbitrary but is
+  // deliberate: an explicitly chosen cursor colour, from either source,
+  // outranks a foreground colour being reused as a fallback.
+  var out = hosts.resolve_terminal_options(
+    {fontcolor: 'lime'}, {cursor: 'blue'});
+  assert.strictEqual(out.theme.cursor, 'blue');
+});
+
 test('save_error_text surfaces the server message on 400', function () {
   assert.strictEqual(
     hosts.save_error_text(400, {error: 'Invalid port "99999" for host "db".'}),

--- a/tests/js/user-hosts.test.js
+++ b/tests/js/user-hosts.test.js
@@ -371,3 +371,50 @@ test('merge_migrated_commands reports no change when nothing matches', function 
   assert.strictEqual(out.changed, false);
   assert.deepStrictEqual(out.payload, []);
 });
+
+var SECRETS = ['credential', 'totp', 'password', 'passphrase', 'privatekey'];
+
+function assert_no_secrets(label, value) {
+  var text = JSON.stringify(value);
+  for (var i = 0; i < SECRETS.length; i++) {
+    assert.ok(text.indexOf(SECRETS[i]) === -1,
+              label + ' must never carry ' + SECRETS[i] + ', got: ' + text);
+  }
+}
+
+test('no builder output can carry a secret field', function () {
+  // The server whitelists keys as a backstop, but a client-side leak would
+  // still transmit the secret over the wire and log it on a validation error.
+  var poisoned = {
+    name: 'a', hostname: 'a.com', port_text: '22', keys_text: '',
+    username: 'u', default_command: 'cmd',
+    credential: 'hunter2', totp: '123456', password: 'p',
+    passphrase: 'pp', privatekey: 'pk'
+  };
+  assert_no_secrets('build_host_payload',
+                    hosts.build_host_payload([poisoned]).hosts);
+
+  var poisoned_current = {
+    last_hostname: 'nas.lan', credential: 'hunter2', totp: '123456',
+    password: 'p', passphrase: 'pp', privatekey: 'pk'
+  };
+  var poisoned_ui = {
+    font_size_text: '14', background: '', foreground: '', cursor: '',
+    encoding: '', term: '', cursor_blink: true, key_source: 'upload',
+    credential: 'hunter2', totp: '123456'
+  };
+  assert_no_secrets('merge_settings',
+                    hosts.merge_settings(poisoned_current, poisoned_ui));
+
+  assert_no_secrets('merge_migrated_commands', hosts.merge_migrated_commands(
+    [{name: 'a', hostname: 'a.com', port: 22, host_keys: [], username: '',
+      default_command: '', credential: 'hunter2', totp: '123456'}],
+    [{hostname: 'a.com', port: 22, command: 'htop'}]).payload);
+});
+
+test('roaming_update refuses every secret-bearing form field', function () {
+  for (var i = 0; i < SECRETS.length; i++) {
+    assert.strictEqual(hosts.roaming_update(SECRETS[i], 'leaked'), null,
+                       SECRETS[i] + ' must not roam');
+  }
+});

--- a/tests/js/user-hosts.test.js
+++ b/tests/js/user-hosts.test.js
@@ -134,3 +134,79 @@ test('build_host_payload returns an empty list for no rows', function () {
   assert.deepStrictEqual(hosts.build_host_payload([]),
                          {hosts: [], error: null, error_index: -1});
 });
+
+function ui(over) {
+  var base = {font_size_text: '', background: '', foreground: '', cursor: '',
+              encoding: '', term: '', cursor_blink: true, key_source: 'upload'};
+  for (var k in over) { base[k] = over[k]; }
+  return base;
+}
+
+test('merge_settings carries roamed last-used values forward', function () {
+  // Regression: the pane only knows appearance keys, and the settings PUT
+  // replaces the whole blob, so every save used to wipe the roamed values.
+  // That is invisible on one machine because localStorage covers it, and
+  // only shows up on a second machine -- which is the point of roaming.
+  var current = {last_hostname: 'nas.lan', last_username: 'ryan', last_port: 2222};
+  var out = hosts.merge_settings(current, ui({font_size_text: '16'}));
+  assert.strictEqual(out.last_hostname, 'nas.lan');
+  assert.strictEqual(out.last_username, 'ryan');
+  assert.strictEqual(out.last_port, 2222);
+  assert.strictEqual(out.font_size, 16);
+});
+
+test('merge_settings omits roaming keys absent from current settings', function () {
+  var out = hosts.merge_settings({}, ui({font_size_text: '16'}));
+  assert.ok(!('last_hostname' in out),
+            'absent keys must be omitted, not sent as null/undefined');
+  assert.ok(!('last_port' in out));
+});
+
+test('merge_settings carries only the three known roaming keys', function () {
+  var out = hosts.merge_settings(
+    {last_hostname: 'a', nonsense: 'x', credential: 'secret'}, ui({}));
+  assert.strictEqual(out.last_hostname, 'a');
+  assert.ok(!('nonsense' in out));
+  assert.ok(!('credential' in out));
+});
+
+test('merge_settings includes appearance values only when non-empty', function () {
+  var out = hosts.merge_settings({}, ui({background: ' black ', foreground: ''}));
+  assert.strictEqual(out.background, 'black');
+  assert.ok(!('foreground' in out));
+});
+
+test('merge_settings omits a non-positive font size', function () {
+  assert.ok(!('font_size' in hosts.merge_settings({}, ui({font_size_text: ''}))));
+  assert.ok(!('font_size' in hosts.merge_settings({}, ui({font_size_text: '0'}))));
+  assert.ok(!('font_size' in hosts.merge_settings({}, ui({font_size_text: 'abc'}))));
+});
+
+test('merge_settings always includes cursor_blink and key_source', function () {
+  var out = hosts.merge_settings({}, ui({cursor_blink: false, key_source: 'stored'}));
+  assert.strictEqual(out.cursor_blink, false);
+  assert.strictEqual(out.key_source, 'stored');
+});
+
+test('roaming_update maps only the three roaming form fields', function () {
+  assert.deepStrictEqual(hosts.roaming_update('hostname', 'nas.lan'),
+                         {key: 'last_hostname', value: 'nas.lan'});
+  assert.deepStrictEqual(hosts.roaming_update('username', 'ryan'),
+                         {key: 'last_username', value: 'ryan'});
+  assert.strictEqual(hosts.roaming_update('credential', 'hunter2'), null);
+  assert.strictEqual(hosts.roaming_update('totp', '123456'), null);
+  assert.strictEqual(hosts.roaming_update('passphrase', 'x'), null);
+});
+
+test('roaming_update coerces port to an integer', function () {
+  // The server validates last_port as an int 1-65535; a string would be
+  // rejected with a 400 the user never sees.
+  assert.deepStrictEqual(hosts.roaming_update('port', '2222'),
+                         {key: 'last_port', value: 2222});
+  assert.strictEqual(typeof hosts.roaming_update('port', '2222').value, 'number');
+});
+
+test('roaming_update drops an unusable port instead of sending it', function () {
+  assert.strictEqual(hosts.roaming_update('port', 'abc'), null);
+  assert.strictEqual(hosts.roaming_update('port', '0'), null);
+});

--- a/tests/js/user-hosts.test.js
+++ b/tests/js/user-hosts.test.js
@@ -288,3 +288,86 @@ test('save_error_text never surfaces server detail on 500', function () {
     hosts.save_error_text(500, {error: '/var/lib/webssh/user-data denied'}),
     'Save failed.');
 });
+
+test('parse_command_key reads a legacy command key', function () {
+  assert.deepStrictEqual(hosts.parse_command_key('command:nas.lan:2222'),
+                         {hostname: 'nas.lan', port: 2222});
+});
+
+test('parse_command_key defaults a missing port to 22', function () {
+  assert.deepStrictEqual(hosts.parse_command_key('command:nas.lan:'),
+                         {hostname: 'nas.lan', port: 22});
+});
+
+test('parse_command_key ignores unrelated localStorage keys', function () {
+  assert.strictEqual(hosts.parse_command_key('hostname'), null);
+  assert.strictEqual(hosts.parse_command_key('webssh_migrated_commands'), null);
+  assert.strictEqual(hosts.parse_command_key(''), null);
+  assert.strictEqual(hosts.parse_command_key(null), null);
+});
+
+test('merge_migrated_commands preserves every field of every host', function () {
+  // This payload replaces the user's whole host list. A dropped field here
+  // silently destroys pinned host keys.
+  var stored = [{
+    name: 'homelab', hostname: 'nas.lan', port: 2222,
+    host_keys: ['ssh-ed25519 AAA'], username: 'ryan', default_command: ''
+  }];
+  var out = hosts.merge_migrated_commands(
+    stored, [{hostname: 'nas.lan', port: 2222, command: 'tmux attach'}]);
+  assert.strictEqual(out.changed, true);
+  assert.deepStrictEqual(out.payload, [{
+    name: 'homelab', hostname: 'nas.lan', port: 2222,
+    host_key: ['ssh-ed25519 AAA'], username: 'ryan',
+    default_command: 'tmux attach'
+  }]);
+});
+
+test('merge_migrated_commands converts host_keys to host_key', function () {
+  var out = hosts.merge_migrated_commands(
+    [{name: 'a', hostname: 'a.com', port: 22, host_keys: ['ssh-rsa AAA'],
+      username: '', default_command: ''}],
+    [{hostname: 'a.com', port: 22, command: 'htop'}]);
+  assert.deepStrictEqual(out.payload[0].host_key, ['ssh-rsa AAA']);
+  assert.ok(!('host_keys' in out.payload[0]));
+});
+
+test('merge_migrated_commands carries through hosts it does not migrate', function () {
+  var stored = [
+    {name: 'a', hostname: 'a.com', port: 22, host_keys: [], username: '',
+     default_command: ''},
+    {name: 'b', hostname: 'b.com', port: 22, host_keys: ['ssh-rsa BBB'],
+     username: 'bob', default_command: 'top'}
+  ];
+  var out = hosts.merge_migrated_commands(
+    stored, [{hostname: 'a.com', port: 22, command: 'htop'}]);
+  assert.strictEqual(out.payload.length, 2);
+  assert.deepStrictEqual(out.payload[1], {
+    name: 'b', hostname: 'b.com', port: 22, host_key: ['ssh-rsa BBB'],
+    username: 'bob', default_command: 'top'
+  });
+});
+
+test('merge_migrated_commands never invents a host', function () {
+  var out = hosts.merge_migrated_commands(
+    [], [{hostname: 'ghost.lan', port: 22, command: 'htop'}]);
+  assert.strictEqual(out.changed, false);
+  assert.deepStrictEqual(out.payload, []);
+});
+
+test('merge_migrated_commands does not overwrite an existing command', function () {
+  var out = hosts.merge_migrated_commands(
+    [{name: 'a', hostname: 'a.com', port: 22, host_keys: [], username: '',
+      default_command: 'already set'}],
+    [{hostname: 'a.com', port: 22, command: 'from localStorage'}]);
+  assert.strictEqual(out.changed, false);
+});
+
+test('merge_migrated_commands reports no change when nothing matches', function () {
+  var out = hosts.merge_migrated_commands(
+    [{name: 'a', hostname: 'a.com', port: 22, host_keys: [], username: '',
+      default_command: ''}],
+    [{hostname: 'other.lan', port: 22, command: 'htop'}]);
+  assert.strictEqual(out.changed, false);
+  assert.deepStrictEqual(out.payload, []);
+});

--- a/tests/js/user-hosts.test.js
+++ b/tests/js/user-hosts.test.js
@@ -114,6 +114,20 @@ test('build_host_payload stops at the first invalid row', function () {
   assert.strictEqual(out.error_index, 0);
 });
 
+test('build_host_payload keeps hosts collected before an invalid row', function () {
+  // Matches the original inline behaviour. Deliberately NOT an empty
+  // list: PUT /api/hosts treats an explicit empty list as "clear my
+  // hosts", so a caller that read .hosts while ignoring .error would
+  // wipe the user's saved hosts.
+  var out = hosts.build_host_payload([
+    row({hostname: 'good.lan'}),
+    row({hostname: 'bad.lan', port_text: '99999'})
+  ]);
+  assert.strictEqual(out.error_index, 1);
+  assert.strictEqual(out.hosts.length, 1);
+  assert.strictEqual(out.hosts[0].hostname, 'good.lan');
+});
+
 test('build_host_payload returns an empty list for no rows', function () {
   // An explicit empty list is a legitimate "clear my hosts", distinct from
   // a failure, and the server honours it as such.

--- a/tests/js/user-hosts.test.js
+++ b/tests/js/user-hosts.test.js
@@ -1,0 +1,31 @@
+'use strict';
+
+var test = require('node:test');
+var assert = require('node:assert');
+var hosts = require('../../webssh/static/js/user-hosts.js');
+
+test('validate_port omits a blank port so the server default applies', function () {
+  assert.deepStrictEqual(hosts.validate_port(''), {omit: true});
+  assert.deepStrictEqual(hosts.validate_port('   '), {omit: true});
+});
+
+test('validate_port accepts values in range', function () {
+  assert.deepStrictEqual(hosts.validate_port('22'), {port: 22});
+  assert.deepStrictEqual(hosts.validate_port('2222'), {port: 2222});
+  assert.deepStrictEqual(hosts.validate_port('65535'), {port: 65535});
+  assert.deepStrictEqual(hosts.validate_port('1'), {port: 1});
+});
+
+test('validate_port rejects out-of-range values instead of rewriting them', function () {
+  // Regression: a typo was once silently clamped to 22, routing around the
+  // server-side 1-65535 check and connecting the user to a port they did
+  // not type.
+  assert.deepStrictEqual(hosts.validate_port('0'), {invalid: true});
+  assert.deepStrictEqual(hosts.validate_port('-5'), {invalid: true});
+  assert.deepStrictEqual(hosts.validate_port('99999'), {invalid: true});
+  assert.deepStrictEqual(hosts.validate_port('65536'), {invalid: true});
+});
+
+test('validate_port rejects non-numeric text', function () {
+  assert.deepStrictEqual(hosts.validate_port('abc'), {invalid: true});
+});

--- a/tests/js/user-hosts.test.js
+++ b/tests/js/user-hosts.test.js
@@ -29,3 +29,9 @@ test('validate_port rejects out-of-range values instead of rewriting them', func
 test('validate_port rejects non-numeric text', function () {
   assert.deepStrictEqual(hosts.validate_port('abc'), {invalid: true});
 });
+
+test('validate_port preserves parseInt leniency for a numeric prefix', function () {
+  // Deliberate: the original inline logic accepted this, and the
+  // extraction must not tighten behaviour. Not a bug to "fix".
+  assert.deepStrictEqual(hosts.validate_port('22abc'), {port: 22});
+});

--- a/tests/js/user-hosts.test.js
+++ b/tests/js/user-hosts.test.js
@@ -210,3 +210,65 @@ test('roaming_update drops an unusable port instead of sending it', function () 
   assert.strictEqual(hosts.roaming_update('port', 'abc'), null);
   assert.strictEqual(hosts.roaming_update('port', '0'), null);
 });
+
+test('resolve_terminal_options lets a URL parameter beat a stored value', function () {
+  // Existing shared links carry ?fontsize= and ?bgcolor=; a stored
+  // preference must never override an explicit URL parameter.
+  var out = hosts.resolve_terminal_options(
+    {fontsize: '20', bgcolor: 'navy'},
+    {font_size: 19, background: 'black'});
+  assert.strictEqual(out.fontSize, 20);
+  assert.strictEqual(out.theme.background, 'navy');
+});
+
+test('resolve_terminal_options falls back to stored values', function () {
+  var out = hosts.resolve_terminal_options({}, {font_size: 19, background: 'black'});
+  assert.strictEqual(out.fontSize, 19);
+  assert.strictEqual(out.theme.background, 'black');
+});
+
+test('resolve_terminal_options falls back to built-in defaults', function () {
+  var out = hosts.resolve_terminal_options({}, {});
+  assert.strictEqual(out.theme.background, 'black');
+  assert.strictEqual(out.theme.foreground, 'white');
+  assert.strictEqual(out.theme.cursor, 'white');
+  assert.strictEqual(out.cursorBlink, true);
+});
+
+test('resolve_terminal_options omits fontSize when nothing resolves', function () {
+  assert.ok(!('fontSize' in hosts.resolve_terminal_options({}, {})));
+});
+
+test('resolve_terminal_options ignores a malformed font size', function () {
+  // A bad stored value must not break the terminal.
+  assert.ok(!('fontSize' in hosts.resolve_terminal_options({fontsize: 'abc'}, {})));
+});
+
+test('resolve_terminal_options honours cursor_blink false', function () {
+  assert.strictEqual(
+    hosts.resolve_terminal_options({}, {cursor_blink: false}).cursorBlink, false);
+});
+
+test('resolve_terminal_options falls back through fontcolor for the cursor', function () {
+  var out = hosts.resolve_terminal_options({fontcolor: 'lime'}, {});
+  assert.strictEqual(out.theme.cursor, 'lime');
+});
+
+test('save_error_text surfaces the server message on 400', function () {
+  assert.strictEqual(
+    hosts.save_error_text(400, {error: 'Invalid port "99999" for host "db".'}),
+    'Invalid port "99999" for host "db".');
+});
+
+test('save_error_text falls back to a generic message on a bodyless 400', function () {
+  assert.strictEqual(hosts.save_error_text(400, null),
+                     'Rejected: check hostnames, ports, and host keys.');
+});
+
+test('save_error_text never surfaces server detail on 500', function () {
+  // Server-state messages can embed filesystem paths. The server already
+  // genericises them; the client must not undo that by echoing a body.
+  assert.strictEqual(
+    hosts.save_error_text(500, {error: '/var/lib/webssh/user-data denied'}),
+    'Save failed.');
+});

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -3,6 +3,7 @@ import random
 import tempfile
 import threading
 import unittest
+from unittest import mock
 import tornado.websocket
 import tornado.gen
 
@@ -877,6 +878,10 @@ class TestUserDataApi(UserDataTestBase):
             '/api/hosts', method='PUT', body=json.dumps({'hosts': []}),
             headers=self.headers)
         self.assertEqual(response.code, 403)
+        self.assertIn(
+            'application/json', response.headers.get('Content-Type', ''))
+        data = json.loads(to_str(response.body))
+        self.assertIn('error', data)
 
     def test_settings_round_trip(self):
         response = self.put('/api/settings', {'settings': {'font_size': 15}})
@@ -944,6 +949,60 @@ class TestUserDataApi(UserDataTestBase):
         self.assertIn('error', data)
         self.assertTrue(data['error'])
         self.assertNotIn('<html', data['error'].lower())
+        # The message describes the caller's own input, not server state.
+        self.assertIn('port', data['error'].lower())
+
+    def test_put_hosts_write_failure_returns_500_without_leaking_path(self):
+        secret_path = '/very/secret/user/data/dir'
+        message = (
+            'Cannot create data directory for user {!r}: permission '
+            'denied. Check ownership of {!r}'.format('alice', secret_path)
+        )
+
+        def boom(base_dir, username, hosts):
+            raise ValueError(message)
+
+        with mock.patch('webssh.user_data.write_hosts', side_effect=boom):
+            with self.assertLogs(level='ERROR') as cm:
+                response = self.put(
+                    '/api/hosts', {'hosts': [{'hostname': 'ok.lan'}]})
+
+        self.assertEqual(response.code, 500)
+        body = to_str(response.body)
+        self.assertNotIn(secret_path, body)
+        self.assertNotIn(self.data_dir, body)
+        data = json.loads(body)
+        self.assertIn('error', data)
+        self.assertEqual(data['error'], 'Failed to save hosts.')
+        self.assertNotIn('/', data['error'])
+        # The real detail, including the path, must still be logged
+        # server-side for operators to diagnose.
+        self.assertTrue(any(secret_path in msg for msg in cm.output))
+
+    def test_put_settings_write_failure_returns_500_without_leaking_path(self):
+        secret_path = '/very/secret/user/data/dir'
+        message = (
+            'Cannot create data directory for user {!r}: permission '
+            'denied. Check ownership of {!r}'.format('alice', secret_path)
+        )
+
+        def boom(base_dir, username, settings):
+            raise ValueError(message)
+
+        with mock.patch('webssh.user_data.write_settings', side_effect=boom):
+            with self.assertLogs(level='ERROR') as cm:
+                response = self.put(
+                    '/api/settings', {'settings': {'font_size': 15}})
+
+        self.assertEqual(response.code, 500)
+        body = to_str(response.body)
+        self.assertNotIn(secret_path, body)
+        self.assertNotIn(self.data_dir, body)
+        data = json.loads(body)
+        self.assertIn('error', data)
+        self.assertEqual(data['error'], 'Failed to save settings.')
+        self.assertNotIn('/', data['error'])
+        self.assertTrue(any(secret_path in msg for msg in cm.output))
 
 
 class TestUserDataApiDisabled(UserDataTestBase):

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -31,7 +31,113 @@ swallow_http_errors = handler.swallow_http_errors
 server_encodings = {e.strip() for e in Server.encodings}
 
 
-class TestAppBase(AsyncHTTPTestCase):
+class OptionsRestoreMixin(object):
+    """Restore tornado's global options after a test mutates them.
+
+    ``options`` is process-global, so a test class that sets an option
+    and does not put it back leaks that value into whichever test runs
+    next. Snapshot the previous value of every option a test overrides
+    and restore exactly that, rather than a hardcoded guess at what it
+    used to be.
+    """
+
+    def override_options(self, **overrides):
+        saved = {}
+        for name in overrides:
+            saved[name] = getattr(options, name)
+        # Registered before anything is mutated, so a failure partway
+        # through still restores whatever was already changed.
+        self.addCleanup(self._restore_options_snapshot, saved)
+        for name, value in overrides.items():
+            setattr(options, name, value)
+
+    def _restore_options_snapshot(self, saved):
+        for name, value in saved.items():
+            setattr(options, name, value)
+
+
+class TestOptionsRestoreMixin(unittest.TestCase):
+
+    class Case(OptionsRestoreMixin, unittest.TestCase):
+        overrides = {}
+        raises = False
+
+        def runTest(self):
+            self.override_options(**self.overrides)
+            if self.raises:
+                raise RuntimeError('boom')
+
+    def run_case(self, overrides, raises=False):
+        case = self.Case()
+        case.overrides = overrides
+        case.raises = raises
+        case.run(unittest.TestResult())
+
+    def test_restores_previous_values(self):
+        self.addCleanup(setattr, options, 'policy', options.policy)
+        self.addCleanup(setattr, options, 'user_hosts', options.user_hosts)
+        options.policy = 'warning'
+        options.user_hosts = False
+
+        self.run_case({'policy': 'reject', 'user_hosts': True})
+
+        self.assertEqual(options.policy, 'warning')
+        self.assertIs(options.user_hosts, False)
+
+    def test_restores_when_the_test_fails(self):
+        self.addCleanup(setattr, options, 'policy', options.policy)
+        options.policy = 'warning'
+
+        self.run_case({'policy': 'reject'}, raises=True)
+
+        self.assertEqual(options.policy, 'warning')
+
+    def test_leaves_untouched_options_alone(self):
+        self.addCleanup(setattr, options, 'policy', options.policy)
+        self.addCleanup(setattr, options, 'origin', options.origin)
+        options.policy = 'warning'
+        options.origin = 'same'
+
+        self.run_case({'policy': 'reject'})
+
+        self.assertEqual(options.origin, 'same')
+
+
+class TestSuiteLeavesOptionsClean(unittest.TestCase):
+    """The suite is the only automated guard on the security invariants,
+    so it must not depend on which test happened to run first.
+
+    Run the classes that mutate the most options and assert every one of
+    them is handed back as it was found.
+    """
+
+    watched = ('debug', 'xsrf', 'policy', 'hostfile', 'syshostfile',
+               'tdstream', 'origin', 'user_hosts', 'userdatadir',
+               'userheader', 'config', 'maxconn')
+
+    def assert_no_leak(self, cls):
+        before = {}
+        for name in self.watched:
+            before[name] = getattr(options, name)
+
+        suite = unittest.TestLoader().loadTestsFromTestCase(cls)
+        suite.run(unittest.TestResult())
+
+        leaked = {}
+        for name in self.watched:
+            after = getattr(options, name)
+            if after != before[name]:
+                leaked[name] = (before[name], after)
+        self.assertEqual(leaked, {})
+
+    def test_user_host_key_isolation_leaves_options_clean(self):
+        self.assert_no_leak(TestUserHostKeyIsolation)
+
+    def test_user_data_api_leaves_options_clean(self):
+        self.assert_no_leak(TestUserDataApi)
+
+
+class TestAppBase(OptionsRestoreMixin, AsyncHTTPTestCase):
 
     def get_httpserver_options(self):
         return get_server_settings(options)
@@ -804,24 +910,23 @@ class UserDataTestBase(TestAppBase):
 
     def get_app(self):
         self.data_dir = tempfile.mkdtemp()
-        options.debug = False
-        options.xsrf = True
-        options.policy = 'warning'
-        options.hostfile = ''
-        options.syshostfile = ''
-        options.tdstream = ''
-        options.origin = 'same'
-        options.user_hosts = self.user_hosts
-        options.userdatadir = self.data_dir
-        options.userheader = 'X-Authentik-Username'
-        self.addCleanup(self._restore_options)
+        self.override_options(
+            debug=False,
+            xsrf=True,
+            policy='warning',
+            hostfile='',
+            syshostfile='',
+            tdstream='',
+            origin='same',
+            # config is deliberately not overridden here: subclasses set it
+            # before get_app runs, and clobbering it would drop their
+            # admin allowlist.
+            user_hosts=self.user_hosts,
+            userdatadir=self.data_dir,
+            userheader='X-Authentik-Username',
+        )
         return make_app(make_handlers(self.io_loop, options),
                         get_app_settings(options))
-
-    def _restore_options(self):
-        options.user_hosts = False
-        options.userdatadir = ''
-        options.config = ''
 
 
 class TestUserDataApi(UserDataTestBase):
@@ -1082,7 +1187,7 @@ class ConnectHostsTestBase(UserDataTestBase):
             yaml.safe_dump({'hosts': [
                 {'name': 'other', 'hostname': self.admin_hostname,
                  'port': 22}]}, f)
-        options.config = self.config_path
+        self.override_options(config=self.config_path)
         super(ConnectHostsTestBase, self).setUp()
         from webssh.user_data import write_hosts
         write_hosts(self.data_dir, 'alice',
@@ -1146,28 +1251,23 @@ class TestUserHostKeyIsolation(TestAppBase):
 
     def get_app(self):
         self.data_dir = tempfile.mkdtemp()
-        options.debug = False
-        options.xsrf = True
-        options.policy = 'reject'
-        # A hostfile is required for the reject policy, and it deliberately
-        # does not contain self.hostname.
-        options.hostfile = make_tests_data_path('known_hosts_example')
-        options.syshostfile = make_tests_data_path('known_hosts_example')
-        options.tdstream = ''
-        options.origin = 'same'
-        options.config = ''
-        options.user_hosts = True
-        options.userdatadir = self.data_dir
-        options.userheader = 'X-Authentik-Username'
-        self.addCleanup(self._restore_options)
+        self.override_options(
+            debug=False,
+            xsrf=True,
+            policy='reject',
+            # A hostfile is required for the reject policy, and it
+            # deliberately does not contain self.hostname.
+            hostfile=make_tests_data_path('known_hosts_example'),
+            syshostfile=make_tests_data_path('known_hosts_example'),
+            tdstream='',
+            origin='same',
+            config='',
+            user_hosts=True,
+            userdatadir=self.data_dir,
+            userheader='X-Authentik-Username',
+        )
         return make_app(make_handlers(self.io_loop, options),
                         get_app_settings(options))
-
-    def _restore_options(self):
-        options.user_hosts = False
-        options.userdatadir = ''
-        options.hostfile = ''
-        options.syshostfile = ''
 
     def setUp(self):
         super(TestUserHostKeyIsolation, self).setUp()

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1125,3 +1125,73 @@ class TestConnectWithUserHostsDisabled(ConnectHostsTestBase):
     def test_host_in_neither_list_is_rejected(self):
         self.assertIn(b'is not allowed',
                       self.post_hostname('127.0.0.2').body)
+
+
+class TestUserHostKeyIsolation(TestAppBase):
+    """A user's personal host key pin must not leak into other requests.
+
+    Under `policy: reject` with no administrator `hosts:` allowlist,
+    check_allowed_hosts returns early and lookup_hostname is the only gate.
+    If a user's pin lands in the process-wide HostKeys store, that user's
+    private bookmark silently becomes a global allowlist entry.
+    """
+
+    # Any syntactically valid key; it never has to match a real server.
+    user_key = ('ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINwZGQmNFADnAAlm5uFLQ'
+                'TrdxqpNxHdgg4JPbB3sR2kr')
+    # Loopback with nothing listening: the allowlist gate runs, then the
+    # connection fails fast instead of hanging on an unroutable address.
+    hostname = '127.0.0.9'
+    port = 7009
+
+    def get_app(self):
+        self.data_dir = tempfile.mkdtemp()
+        options.debug = False
+        options.xsrf = True
+        options.policy = 'reject'
+        # A hostfile is required for the reject policy, and it deliberately
+        # does not contain self.hostname.
+        options.hostfile = make_tests_data_path('known_hosts_example')
+        options.syshostfile = make_tests_data_path('known_hosts_example')
+        options.tdstream = ''
+        options.origin = 'same'
+        options.config = ''
+        options.user_hosts = True
+        options.userdatadir = self.data_dir
+        options.userheader = 'X-Authentik-Username'
+        self.addCleanup(self._restore_options)
+        return make_app(make_handlers(self.io_loop, options),
+                        get_app_settings(options))
+
+    def _restore_options(self):
+        options.user_hosts = False
+        options.userdatadir = ''
+        options.hostfile = ''
+        options.syshostfile = ''
+
+    def setUp(self):
+        super(TestUserHostKeyIsolation, self).setUp()
+        from webssh.user_data import write_hosts
+        write_hosts(self.data_dir, 'alice',
+                    [{'hostname': self.hostname, 'port': self.port,
+                      'host_key': [self.user_key]}])
+
+    def post_as(self, username):
+        headers = {'Cookie': '_xsrf=yummy'}
+        if username:
+            headers['X-Authentik-Username'] = username
+        body = ('hostname={}&port={}&username=robey&password=foo'
+                '&_xsrf=yummy').format(self.hostname, self.port)
+        return self.fetch('/', method='POST', body=body, headers=headers)
+
+    def test_alice_reaches_her_own_host(self):
+        # Her own pin satisfies the reject gate for her own request.
+        self.assertNotIn(b'is not allowed', self.post_as('alice').body)
+
+    def test_alice_pin_does_not_leak_to_another_user(self):
+        self.assertNotIn(b'is not allowed', self.post_as('alice').body)
+        self.assertIn(b'is not allowed', self.post_as('bob').body)
+
+    def test_alice_pin_does_not_leak_to_anonymous_request(self):
+        self.assertNotIn(b'is not allowed', self.post_as('alice').body)
+        self.assertIn(b'is not allowed', self.post_as(None).body)

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,6 +1,8 @@
 import json
 import random
+import tempfile
 import threading
+import unittest
 import tornado.websocket
 import tornado.gen
 
@@ -790,3 +792,122 @@ class TestAppWithUnknownEncoding(OtherTestBase):
         dic = json.loads(to_str(response.body))
         self.assert_status_none(dic)
         self.assertEqual(dic['encoding'], 'utf-8')
+
+
+class UserDataTestBase(TestAppBase):
+
+    headers = {'Cookie': '_xsrf=yummy',
+               'X-Authentik-Username': 'alice'}
+    user_hosts = True
+
+    def get_app(self):
+        self.data_dir = tempfile.mkdtemp()
+        options.debug = False
+        options.xsrf = True
+        options.policy = 'warning'
+        options.hostfile = ''
+        options.syshostfile = ''
+        options.tdstream = ''
+        options.origin = 'same'
+        options.user_hosts = self.user_hosts
+        options.userdatadir = self.data_dir
+        options.userheader = 'X-Authentik-Username'
+        self.addCleanup(self._restore_options)
+        return make_app(make_handlers(self.io_loop, options),
+                        get_app_settings(options))
+
+    def _restore_options(self):
+        options.user_hosts = False
+        options.userdatadir = ''
+        options.config = ''
+
+
+class TestUserDataApi(UserDataTestBase):
+
+    def put(self, path, payload, headers=None):
+        body = json.dumps(payload)
+        hdrs = dict(headers if headers is not None else self.headers)
+        hdrs['Content-Type'] = 'application/json'
+        hdrs['X-Xsrftoken'] = 'yummy'
+        return self.fetch(path, method='PUT', body=body, headers=hdrs)
+
+    def test_get_hosts_empty(self):
+        response = self.fetch('/api/hosts', headers=self.headers)
+        self.assertEqual(response.code, 200)
+        data = json.loads(to_str(response.body))
+        self.assertEqual(data['user_hosts'], [])
+        self.assertIn('admin_hosts', data)
+
+    def test_put_then_get_hosts(self):
+        response = self.put('/api/hosts', {'hosts': [{'hostname': 'nas.lan',
+                                                      'port': 2222}]})
+        self.assertEqual(response.code, 200)
+        response = self.fetch('/api/hosts', headers=self.headers)
+        data = json.loads(to_str(response.body))
+        self.assertEqual(len(data['user_hosts']), 1)
+        self.assertEqual(data['user_hosts'][0]['port'], 2222)
+
+    def test_put_invalid_host_returns_400_and_preserves_data(self):
+        self.put('/api/hosts', {'hosts': [{'hostname': 'good.lan'}]})
+        response = self.put('/api/hosts',
+                            {'hosts': [{'hostname': 'bad', 'port': 0}]})
+        self.assertEqual(response.code, 400)
+        response = self.fetch('/api/hosts', headers=self.headers)
+        data = json.loads(to_str(response.body))
+        self.assertEqual(data['user_hosts'][0]['hostname'], 'good.lan')
+
+    def test_put_malformed_json_returns_400(self):
+        response = self.fetch(
+            '/api/hosts', method='PUT', body='{not json',
+            headers=dict(self.headers, **{'X-Xsrftoken': 'yummy',
+                                          'Content-Type': 'application/json'}))
+        self.assertEqual(response.code, 400)
+
+    def test_missing_auth_header_returns_401(self):
+        response = self.fetch('/api/hosts', headers={'Cookie': '_xsrf=yummy'})
+        self.assertEqual(response.code, 401)
+
+    def test_invalid_username_returns_400(self):
+        response = self.fetch('/api/hosts', headers={
+            'Cookie': '_xsrf=yummy', 'X-Authentik-Username': '../etc'})
+        self.assertEqual(response.code, 400)
+
+    def test_put_without_xsrf_returns_403(self):
+        response = self.fetch(
+            '/api/hosts', method='PUT', body=json.dumps({'hosts': []}),
+            headers=self.headers)
+        self.assertEqual(response.code, 403)
+
+    def test_settings_round_trip(self):
+        response = self.put('/api/settings', {'settings': {'font_size': 15}})
+        self.assertEqual(response.code, 200)
+        response = self.fetch('/api/settings', headers=self.headers)
+        data = json.loads(to_str(response.body))
+        self.assertEqual(data['settings']['font_size'], 15)
+
+    def test_settings_drops_secrets(self):
+        self.put('/api/settings',
+                 {'settings': {'font_size': 15, 'password': 'hunter2'}})
+        response = self.fetch('/api/settings', headers=self.headers)
+        data = json.loads(to_str(response.body))
+        self.assertNotIn('password', data['settings'])
+
+    def test_users_are_isolated(self):
+        self.put('/api/hosts', {'hosts': [{'hostname': 'alice.lan'}]})
+        response = self.fetch('/api/hosts', headers={
+            'Cookie': '_xsrf=yummy', 'X-Authentik-Username': 'bob'})
+        data = json.loads(to_str(response.body))
+        self.assertEqual(data['user_hosts'], [])
+
+
+class TestUserDataApiDisabled(UserDataTestBase):
+
+    user_hosts = False
+
+    def test_get_hosts_returns_403(self):
+        response = self.fetch('/api/hosts', headers=self.headers)
+        self.assertEqual(response.code, 403)
+
+    def test_get_settings_returns_403(self):
+        response = self.fetch('/api/settings', headers=self.headers)
+        self.assertEqual(response.code, 403)

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1084,7 +1084,7 @@ class ConnectHostsTestBase(UserDataTestBase):
 
     def post_hostname(self, hostname):
         body = ('hostname={}&port=7000&username=robey&password=foo'
-                 '&_xsrf=yummy').format(hostname)
+                '&_xsrf=yummy').format(hostname)
         return self.fetch('/', method='POST', body=body,
                           headers=self.headers)
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1005,6 +1005,12 @@ class TestUserDataApi(UserDataTestBase):
         self.assertNotIn('/', data['error'])
         self.assertTrue(any(secret_path in msg for msg in cm.output))
 
+    def test_settings_pane_returns_fragment(self):
+        response = self.fetch('/settings-pane', headers=self.headers)
+        self.assertEqual(response.code, 200)
+        self.assertIn(b'settings-pane', response.body)
+        self.assertNotIn(b'<html', response.body)
+
 
 class TestUserDataApiDisabled(UserDataTestBase):
 
@@ -1017,6 +1023,10 @@ class TestUserDataApiDisabled(UserDataTestBase):
     def test_get_settings_returns_403(self):
         response = self.fetch('/api/settings', headers=self.headers)
         self.assertEqual(response.code, 403)
+
+    def test_settings_pane_returns_404(self):
+        response = self.fetch('/settings-pane', headers=self.headers)
+        self.assertEqual(response.code, 404)
 
 
 class TestEffectiveHosts(unittest.TestCase):

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,4 +1,5 @@
 import json
+import os
 import random
 import tempfile
 import threading
@@ -1016,3 +1017,101 @@ class TestUserDataApiDisabled(UserDataTestBase):
     def test_get_settings_returns_403(self):
         response = self.fetch('/api/settings', headers=self.headers)
         self.assertEqual(response.code, 403)
+
+
+class TestEffectiveHosts(unittest.TestCase):
+    """Unit-level checks of the admin/user host merge."""
+
+    def _handler(self, admin_hosts, user_hosts):
+        from webssh.handler import IndexHandler
+        h = IndexHandler.__new__(IndexHandler)
+        h.allowed_hosts = admin_hosts
+        h._user_hosts = user_hosts
+        h.get_user_hosts = lambda: h._user_hosts
+        return h
+
+    def test_admin_host_wins_collision(self):
+        from webssh.handler import IndexHandler
+        admin = [{'name': 'prod', 'hostname': '10.0.1.5', 'port': 22,
+                  'host_keys': ['ssh-ed25519 AAAAadmin']}]
+        user = [{'name': 'mine', 'hostname': '10.0.1.5', 'port': 22,
+                 'host_keys': ['ssh-ed25519 AAAAuser']}]
+        h = self._handler(admin, user)
+        effective = IndexHandler.get_effective_hosts(h)
+        self.assertEqual(len(effective), 1)
+        self.assertEqual(effective[0]['host_keys'], ['ssh-ed25519 AAAAadmin'])
+
+    def test_different_port_is_not_a_collision(self):
+        from webssh.handler import IndexHandler
+        admin = [{'name': 'prod', 'hostname': '10.0.1.5', 'port': 22,
+                  'host_keys': []}]
+        user = [{'name': 'mine', 'hostname': '10.0.1.5', 'port': 2222,
+                 'host_keys': []}]
+        h = self._handler(admin, user)
+        self.assertEqual(len(IndexHandler.get_effective_hosts(h)), 2)
+
+    def test_user_hosts_appended(self):
+        from webssh.handler import IndexHandler
+        h = self._handler([{'name': 'a', 'hostname': 'a.com', 'port': 22,
+                            'host_keys': []}],
+                          [{'name': 'b', 'hostname': 'b.com', 'port': 22,
+                            'host_keys': []}])
+        names = [x['name'] for x in IndexHandler.get_effective_hosts(h)]
+        self.assertEqual(names, ['a', 'b'])
+
+
+class ConnectHostsTestBase(UserDataTestBase):
+    """Admin allowlist that deliberately excludes the user's saved host."""
+
+    admin_hostname = '10.9.9.9'
+
+    def setUp(self):
+        import yaml
+        fd, self.config_path = tempfile.mkstemp(suffix='.yaml')
+        with os.fdopen(fd, 'w') as f:
+            yaml.safe_dump({'hosts': [
+                {'name': 'other', 'hostname': self.admin_hostname,
+                 'port': 22}]}, f)
+        options.config = self.config_path
+        super(ConnectHostsTestBase, self).setUp()
+        from webssh.user_data import write_hosts
+        write_hosts(self.data_dir, 'alice',
+                    [{'hostname': '127.0.0.1', 'port': 7000}])
+
+    def tearDown(self):
+        os.unlink(self.config_path)
+        super(ConnectHostsTestBase, self).tearDown()
+
+    def post_hostname(self, hostname):
+        body = ('hostname={}&port=7000&username=robey&password=foo'
+                 '&_xsrf=yummy').format(hostname)
+        return self.fetch('/', method='POST', body=body,
+                          headers=self.headers)
+
+
+class TestConnectWithUserHostsEnabled(ConnectHostsTestBase):
+
+    user_hosts = True
+
+    def test_user_host_passes_the_allowlist(self):
+        # The allowlist must not reject it. The SSH connection itself will
+        # fail (no server on that port), which is fine and not what we assert.
+        self.assertNotIn(b'is not allowed',
+                         self.post_hostname('127.0.0.1').body)
+
+    def test_host_in_neither_list_is_rejected(self):
+        self.assertIn(b'is not allowed',
+                      self.post_hostname('127.0.0.2').body)
+
+
+class TestConnectWithUserHostsDisabled(ConnectHostsTestBase):
+
+    user_hosts = False
+
+    def test_user_host_is_rejected_when_feature_disabled(self):
+        self.assertIn(b'is not allowed',
+                      self.post_hostname('127.0.0.1').body)
+
+    def test_host_in_neither_list_is_rejected(self):
+        self.assertIn(b'is not allowed',
+                      self.post_hostname('127.0.0.2').body)

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -899,6 +899,52 @@ class TestUserDataApi(UserDataTestBase):
         data = json.loads(to_str(response.body))
         self.assertEqual(data['user_hosts'], [])
 
+    def test_put_hosts_missing_key_returns_400_and_preserves_data(self):
+        self.put('/api/hosts', {'hosts': [{'hostname': 'good.lan'}]})
+        response = self.put('/api/hosts', {})
+        self.assertEqual(response.code, 400)
+        response = self.put('/api/hosts', {'hosts_typo': []})
+        self.assertEqual(response.code, 400)
+        response = self.fetch('/api/hosts', headers=self.headers)
+        data = json.loads(to_str(response.body))
+        self.assertEqual(len(data['user_hosts']), 1)
+        self.assertEqual(data['user_hosts'][0]['hostname'], 'good.lan')
+
+    def test_put_hosts_explicit_empty_clears_data(self):
+        self.put('/api/hosts', {'hosts': [{'hostname': 'good.lan'}]})
+        response = self.put('/api/hosts', {'hosts': []})
+        self.assertEqual(response.code, 200)
+        response = self.fetch('/api/hosts', headers=self.headers)
+        data = json.loads(to_str(response.body))
+        self.assertEqual(data['user_hosts'], [])
+
+    def test_put_settings_missing_key_returns_400_and_preserves_data(self):
+        self.put('/api/settings', {'settings': {'font_size': 15}})
+        response = self.put('/api/settings', {})
+        self.assertEqual(response.code, 400)
+        response = self.fetch('/api/settings', headers=self.headers)
+        data = json.loads(to_str(response.body))
+        self.assertEqual(data['settings']['font_size'], 15)
+
+    def test_put_settings_explicit_empty_clears_data(self):
+        self.put('/api/settings', {'settings': {'font_size': 15}})
+        response = self.put('/api/settings', {'settings': {}})
+        self.assertEqual(response.code, 200)
+        response = self.fetch('/api/settings', headers=self.headers)
+        data = json.loads(to_str(response.body))
+        self.assertEqual(data['settings'], {})
+
+    def test_put_invalid_host_returns_json_error_with_message(self):
+        response = self.put(
+            '/api/hosts', {'hosts': [{'hostname': 'bad', 'port': 0}]})
+        self.assertEqual(response.code, 400)
+        self.assertIn(
+            'application/json', response.headers.get('Content-Type', ''))
+        data = json.loads(to_str(response.body))
+        self.assertIn('error', data)
+        self.assertTrue(data['error'])
+        self.assertNotIn('<html', data['error'].lower())
+
 
 class TestUserDataApiDisabled(UserDataTestBase):
 

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -327,6 +327,9 @@ class TestIndexHandlerAllowedHosts(unittest.TestCase):
     def _make_handler(self, allowed_hosts=None):
         handler_obj = Mock(spec=IndexHandler)
         handler_obj.allowed_hosts = allowed_hosts or []
+        handler_obj.get_user_hosts = lambda: []
+        handler_obj.get_effective_hosts = lambda: \
+            IndexHandler.get_effective_hosts(handler_obj)
         handler_obj.check_allowed_hosts = lambda h, p: \
             IndexHandler.check_allowed_hosts(handler_obj, h, p)
         return handler_obj

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -1,3 +1,4 @@
+import base64
 import io
 import tempfile
 import unittest
@@ -8,6 +9,7 @@ from tornado.httputil import HTTPServerRequest
 from tornado.options import options
 from tests.utils import read_file, make_tests_data_path
 from webssh import handler
+from webssh import user_data
 from webssh import user_keys
 from webssh.handler import (
     IndexHandler, MixinHandler, WsockHandler, PrivateKey, InvalidValueError,
@@ -15,9 +17,9 @@ from webssh.handler import (
 )
 
 try:
-    from unittest.mock import Mock
+    from unittest.mock import Mock, patch
 except ImportError:
-    from mock import Mock
+    from mock import Mock, patch
 
 
 class TestMixinHandler(unittest.TestCase):
@@ -364,6 +366,100 @@ class TestIndexHandlerAllowedHosts(unittest.TestCase):
         with self.assertRaises(tornado.web.HTTPError) as ctx:
             h.check_allowed_hosts('10.0.1.5', 2222)
         self.assertEqual(ctx.exception.status_code, 403)
+
+
+class FakeHostKeys(object):
+    """Records what load_configured_host_key/_add_host_key actually store,
+    so tests can assert against the paramiko host key store itself rather
+    than just the merged host list."""
+
+    def __init__(self):
+        self.added = []
+
+    def add(self, hostname, key_type, key):
+        self.added.append((hostname, key_type, key))
+
+
+class TestLoadConfiguredHostKey(unittest.TestCase):
+
+    # Two distinct, valid ed25519 public keys (different key material).
+    admin_key = ('ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGrAb7GEqLHlbAF9gMdvD'
+                 'ZzdKnd2MlrZ2sAs5qF7XMRF')
+    user_key = ('ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIEF7nSZPAVEiuuEjgBzsnv'
+                'kt5yRbRIRTS8tYY7eyhEVV')
+
+    def _key_object(self, key_str):
+        b64 = key_str.strip().split()[1]
+        return paramiko.Ed25519Key(data=base64.b64decode(b64))
+
+    def _make_handler(self, allowed_hosts):
+        handler_obj = Mock(spec=IndexHandler)
+        handler_obj.allowed_hosts = allowed_hosts
+        handler_obj.get_effective_hosts = lambda: \
+            IndexHandler.get_effective_hosts(handler_obj)
+        handler_obj.load_configured_host_key = lambda h, p: \
+            IndexHandler.load_configured_host_key(handler_obj, h, p)
+        handler_obj._add_host_key = lambda h, p, k: \
+            IndexHandler._add_host_key(handler_obj, h, p, k)
+        handler_obj.ssh_client = Mock()
+        handler_obj.ssh_client._host_keys = FakeHostKeys()
+        return handler_obj
+
+    def test_admin_key_wins_collision(self):
+        # Admin and user both pin a DIFFERENT key for the same hostname:port.
+        # The admin key must be what reaches the paramiko host key store,
+        # and the user's key must never appear there.
+        admin = [{'name': 'prod', 'hostname': '10.0.1.5', 'port': 22,
+                  'host_keys': [self.admin_key]}]
+        user = [{'name': 'mine', 'hostname': '10.0.1.5', 'port': 22,
+                 'host_keys': [self.user_key]}]
+        h = self._make_handler(admin)
+        h.get_user_hosts = lambda: user
+
+        h.load_configured_host_key('10.0.1.5', 22)
+
+        added = h.ssh_client._host_keys.added
+        self.assertEqual(len(added), 1)
+        hostname, key_type, key = added[0]
+        self.assertEqual(hostname, '10.0.1.5')
+        self.assertEqual(key_type, 'ssh-ed25519')
+        self.assertEqual(key, self._key_object(self.admin_key))
+        self.assertNotEqual(key, self._key_object(self.user_key))
+
+    def test_no_admin_allowlist_still_loads_user_key(self):
+        # This is the dropped-guard branch: no administrator allowlist is
+        # configured at all, but a personal host's pinned key must still
+        # load into the paramiko store.
+        user = [{'name': 'mine', 'hostname': '10.0.1.5', 'port': 22,
+                 'host_keys': [self.user_key]}]
+        h = self._make_handler([])
+        h.get_user_hosts = lambda: user
+
+        h.load_configured_host_key('10.0.1.5', 22)
+
+        added = h.ssh_client._host_keys.added
+        self.assertEqual(len(added), 1)
+        hostname, key_type, key = added[0]
+        self.assertEqual(hostname, '10.0.1.5')
+        self.assertEqual(key, self._key_object(self.user_key))
+
+    def test_feature_disabled_user_key_not_loaded(self):
+        # Drive the real get_user_hosts gating (not a stub) so this proves
+        # the disabled-feature path, not just an empty-list stand-in.
+        h = self._make_handler([])
+        h.user_hosts_enabled = False
+        h.user_data_dir = '/nonexistent-should-never-be-read'
+        h.user_header = 'X-Authentik-Username'
+        h.request = Mock(headers={'X-Authentik-Username': 'alice'})
+        h.get_user_hosts = lambda: IndexHandler.get_user_hosts(h)
+
+        with patch.object(user_data, 'read_hosts', return_value=[
+                {'name': 'mine', 'hostname': '10.0.1.5', 'port': 22,
+                 'host_keys': [self.user_key]}]) as mock_read:
+            h.load_configured_host_key('10.0.1.5', 22)
+            mock_read.assert_not_called()
+
+        self.assertEqual(h.ssh_client._host_keys.added, [])
 
 
 class TestIndexHandler(unittest.TestCase):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import tempfile
 import unittest
@@ -6,7 +7,9 @@ import yaml
 from tornado.options import options
 from tornado.web import Application
 from webssh import handler
-from webssh.main import app_listen, reload_config
+from webssh.main import (
+    app_listen, reload_config, check_user_hosts_configuration
+)
 
 
 class TestMain(unittest.TestCase):
@@ -24,6 +27,37 @@ class TestMain(unittest.TestCase):
         server_settings = dict(ssl_options='enabled')
         app_listen(app, 80, '127.0.0.1', server_settings)
         self.assertTrue(handler.redirecting)
+
+
+class TestCheckUserHostsConfiguration(unittest.TestCase):
+
+    def test_disabled_does_nothing(self):
+        with self.assertLogs(level='WARNING') as cm:
+            logging.warning('sentinel')
+            check_user_hosts_configuration(False, '')
+        self.assertEqual(len(cm.output), 1)
+
+    def test_enabled_without_data_dir_warns(self):
+        with self.assertLogs(level='WARNING') as cm:
+            check_user_hosts_configuration(True, '')
+        self.assertTrue(any(
+            'user_hosts is enabled but no userdatadir or userkeydir' in msg
+            for msg in cm.output
+        ))
+
+    def test_enabled_with_data_dir_checks_directory(self):
+        data_dir = tempfile.mkdtemp()
+        try:
+            # Should not raise, and should not log the "not configured"
+            # warning when a data dir is present (a separate security
+            # warning about missing trusted_proxies is expected instead).
+            with self.assertLogs(level='WARNING') as cm:
+                check_user_hosts_configuration(True, data_dir)
+            self.assertFalse(any(
+                'not configured' in msg for msg in cm.output
+            ))
+        finally:
+            os.rmdir(data_dir)
 
 
 class TestReloadConfig(unittest.TestCase):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -46,18 +46,26 @@ class TestCheckUserHostsConfiguration(unittest.TestCase):
         ))
 
     def test_enabled_with_data_dir_checks_directory(self):
-        data_dir = tempfile.mkdtemp()
+        parent = tempfile.mkdtemp()
+        data_dir = os.path.join(parent, 'does-not-exist-yet')
         try:
-            # Should not raise, and should not log the "not configured"
-            # warning when a data dir is present (a separate security
-            # warning about missing trusted_proxies is expected instead).
+            # Should not log the "not configured" warning when a data dir
+            # is present (a separate security warning about missing
+            # trusted_proxies is expected instead), and should actually
+            # reach check_user_data_dir -- proven by the directory getting
+            # created, since it does not exist beforehand.
+            self.assertFalse(os.path.isdir(data_dir))
             with self.assertLogs(level='WARNING') as cm:
                 check_user_hosts_configuration(True, data_dir)
             self.assertFalse(any(
-                'not configured' in msg for msg in cm.output
+                'user_hosts is enabled but no userdatadir' in msg
+                for msg in cm.output
             ))
+            self.assertTrue(os.path.isdir(data_dir))
         finally:
-            os.rmdir(data_dir)
+            if os.path.isdir(data_dir):
+                os.rmdir(data_dir)
+            os.rmdir(parent)
 
 
 class TestReloadConfig(unittest.TestCase):

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -242,6 +242,8 @@ class TestSettings(unittest.TestCase):
             'userkeydir': '',
             'userheader': 'X-Authentik-Username',
             'policy': 'warning',
+            'userdatadir': '',
+            'user_hosts': False,
         }
         defaults.update(overrides)
         return type('Options', (), defaults)()
@@ -512,3 +514,83 @@ class TestParseHostEntry(unittest.TestCase):
         with self.assertRaises(ValueError):
             parse_host_entry({
                 'hostname': 'a.com', 'host_key': 'ssh-ed25519 not!base64!'})
+
+
+class TestUserDataSettings(unittest.TestCase):
+
+    def test_userdatadir_falls_back_to_userkeydir(self):
+        from webssh.settings import get_user_data_dir_setting
+
+        class Opts(object):
+            userdatadir = ''
+            userkeydir = '/var/lib/webssh/keys'
+
+        self.assertEqual(get_user_data_dir_setting(Opts()),
+                         '/var/lib/webssh/keys')
+
+    def test_userdatadir_wins_when_set(self):
+        from webssh.settings import get_user_data_dir_setting
+
+        class Opts(object):
+            userdatadir = '/var/lib/webssh/data'
+            userkeydir = '/var/lib/webssh/keys'
+
+        self.assertEqual(get_user_data_dir_setting(Opts()),
+                         '/var/lib/webssh/data')
+
+    def test_userdatadir_empty_when_neither_set(self):
+        from webssh.settings import get_user_data_dir_setting
+
+        class Opts(object):
+            userdatadir = ''
+            userkeydir = ''
+
+        self.assertEqual(get_user_data_dir_setting(Opts()), '')
+
+    def test_check_user_data_dir_creates_directory(self):
+        import tempfile
+        from webssh.settings import check_user_data_dir
+        base = tempfile.mkdtemp()
+        target = os.path.join(base, 'data')
+        check_user_data_dir(target, tdstream='10.0.0.1')
+        self.assertTrue(os.path.isdir(target))
+
+    def test_check_user_data_dir_noop_when_empty(self):
+        from webssh.settings import check_user_data_dir
+        self.assertIsNone(check_user_data_dir(''))
+
+    def test_check_user_data_dir_rejects_file(self):
+        import tempfile
+        from webssh.settings import check_user_data_dir
+        fd, path = tempfile.mkstemp()
+        os.close(fd)
+        with self.assertRaises(ValueError):
+            check_user_data_dir(path, tdstream='10.0.0.1')
+
+
+class TestApplyUserHostsConfig(unittest.TestCase):
+
+    def test_user_hosts_and_userdatadir_from_config(self):
+        import tempfile
+        import yaml
+        from tornado.options import options as opts
+        from webssh.settings import apply_config_settings
+
+        fd, path = tempfile.mkstemp(suffix='.yaml')
+        with os.fdopen(fd, 'w') as f:
+            yaml.safe_dump({
+                'user_hosts': True, 'userdatadir': '/tmp/webssh-data'}, f)
+
+        old_config = opts.config
+        old_flag = opts.user_hosts
+        old_dir = opts.userdatadir
+        try:
+            opts.config = path
+            apply_config_settings(opts)
+            self.assertTrue(opts.user_hosts)
+            self.assertEqual(opts.userdatadir, '/tmp/webssh-data')
+        finally:
+            opts.config = old_config
+            opts.user_hosts = old_flag
+            opts.userdatadir = old_dir
+            os.unlink(path)

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -460,3 +460,55 @@ class TestSettings(unittest.TestCase):
                 self.assertIn('permission denied', str(ctx.exception))
             finally:
                 os.chmod(parent, 0o700)
+
+
+class TestParseHostEntry(unittest.TestCase):
+
+    def test_minimal_entry(self):
+        from webssh.settings import parse_host_entry
+        host = parse_host_entry({'hostname': 'example.com'})
+        self.assertEqual(host, {
+            'name': 'example.com',
+            'hostname': 'example.com',
+            'port': 22,
+            'host_keys': [],
+        })
+
+    def test_full_entry_with_string_host_key(self):
+        from webssh.settings import parse_host_entry
+        key = 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGrAb7GEqLHlbAF9gMdvDZzdKnd2MlrZ2sAs5qF7XMRF'
+        host = parse_host_entry({
+            'name': 'Prod', 'hostname': '10.0.1.5', 'port': 2222,
+            'host_key': key,
+        })
+        self.assertEqual(host['name'], 'Prod')
+        self.assertEqual(host['port'], 2222)
+        self.assertEqual(host['host_keys'], [key])
+
+    def test_missing_hostname(self):
+        from webssh.settings import parse_host_entry
+        with self.assertRaises(ValueError):
+            parse_host_entry({'name': 'nope'})
+
+    def test_not_a_mapping(self):
+        from webssh.settings import parse_host_entry
+        with self.assertRaises(ValueError):
+            parse_host_entry('example.com')
+
+    def test_invalid_port(self):
+        from webssh.settings import parse_host_entry
+        for port in [0, 70000, -1]:
+            with self.assertRaises(ValueError):
+                parse_host_entry({'hostname': 'a.com', 'port': port})
+
+    def test_invalid_host_key_type(self):
+        from webssh.settings import parse_host_entry
+        with self.assertRaises(ValueError):
+            parse_host_entry({
+                'hostname': 'a.com', 'host_key': 'ssh-dss AAAAB3Nz'})
+
+    def test_invalid_host_key_base64(self):
+        from webssh.settings import parse_host_entry
+        with self.assertRaises(ValueError):
+            parse_host_entry({
+                'hostname': 'a.com', 'host_key': 'ssh-ed25519 not!base64!'})

--- a/tests/test_user_data.py
+++ b/tests/test_user_data.py
@@ -180,3 +180,47 @@ class TestRoundTrip(unittest.TestCase):
         write_hosts(self.base, 'alice', [{'hostname': 'nas.lan'}])
         entries = os.listdir(get_user_data_dir(self.base, 'alice'))
         self.assertEqual(sorted(entries), ['hosts.json'])
+
+    def _write_raw(self, filename, text):
+        user_dir = get_user_data_dir(self.base, 'alice')
+        if not os.path.isdir(user_dir):
+            os.makedirs(user_dir, mode=0o700)
+        path = os.path.join(user_dir, filename)
+        with open(path, 'w') as f:
+            f.write(text)
+        return path
+
+    def test_corrupt_file_is_quarantined_not_lost(self):
+        # A corrupt file reads as empty, and the client's next save would
+        # then overwrite it with an empty list. The original must survive.
+        path = self._write_raw('hosts.json', '{not json at all')
+        self.assertEqual(read_hosts(self.base, 'alice'), [])
+        self.assertFalse(os.path.exists(path))
+        with open(path + '.corrupt') as f:
+            self.assertEqual(f.read(), '{not json at all')
+
+        write_hosts(self.base, 'alice', [])
+        with open(path + '.corrupt') as f:
+            self.assertEqual(f.read(), '{not json at all')
+
+    def test_wrong_shape_file_is_quarantined(self):
+        path = self._write_raw(
+            'hosts.json', json.dumps({'version': 1, 'hosts': 'not-a-list'}))
+        self.assertEqual(read_hosts(self.base, 'alice'), [])
+        self.assertTrue(os.path.exists(path + '.corrupt'))
+
+    def test_quarantine_does_not_overwrite_existing_corrupt_file(self):
+        path = self._write_raw('hosts.json', 'first')
+        self.assertEqual(read_hosts(self.base, 'alice'), [])
+        self._write_raw('hosts.json', 'second')
+        self.assertEqual(read_hosts(self.base, 'alice'), [])
+
+        with open(path + '.corrupt') as f:
+            self.assertEqual(f.read(), 'first')
+        with open(path + '.corrupt.1') as f:
+            self.assertEqual(f.read(), 'second')
+
+    def test_corrupt_settings_file_is_quarantined(self):
+        path = self._write_raw('settings.json', 'nope')
+        self.assertEqual(read_settings(self.base, 'alice'), {})
+        self.assertTrue(os.path.exists(path + '.corrupt'))

--- a/tests/test_user_data.py
+++ b/tests/test_user_data.py
@@ -1,0 +1,182 @@
+import json
+import os
+import stat
+import tempfile
+import unittest
+
+from webssh.user_data import (
+    SCHEMA_VERSION, get_user_data_dir, read_hosts, write_hosts,
+    read_settings, write_settings, validate_hosts, validate_settings
+)
+
+
+VALID_KEY = ('ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGrAb7GEqLHlbAF9gMdvDZzd'
+             'Knd2MlrZ2sAs5qF7XMRF')
+
+
+class TestGetUserDataDir(unittest.TestCase):
+
+    def setUp(self):
+        self.base = tempfile.mkdtemp()
+
+    def test_valid_username(self):
+        path = get_user_data_dir(self.base, 'alice')
+        self.assertTrue(path.endswith(os.sep + 'alice'))
+
+    def test_path_traversal_rejected(self):
+        for name in ['../etc', 'foo/bar', '..', '.hidden', '']:
+            with self.assertRaises(ValueError):
+                get_user_data_dir(self.base, name)
+
+
+class TestValidateHosts(unittest.TestCase):
+
+    def test_normalizes_minimal_host(self):
+        result = validate_hosts([{'hostname': 'nas.lan'}])
+        self.assertEqual(result, [{
+            'name': 'nas.lan', 'hostname': 'nas.lan', 'port': 22,
+            'host_keys': [], 'username': '', 'default_command': '',
+        }])
+
+    def test_keeps_user_only_fields(self):
+        result = validate_hosts([{
+            'hostname': 'nas.lan', 'port': 2222, 'name': 'homelab',
+            'host_key': VALID_KEY, 'username': 'ryan',
+            'default_command': 'tmux attach',
+        }])
+        self.assertEqual(result[0]['username'], 'ryan')
+        self.assertEqual(result[0]['default_command'], 'tmux attach')
+        self.assertEqual(result[0]['host_keys'], [VALID_KEY])
+
+    def test_drops_unknown_fields(self):
+        result = validate_hosts([{'hostname': 'a.com', 'password': 'hunter2'}])
+        self.assertNotIn('password', result[0])
+
+    def test_rejects_non_list(self):
+        with self.assertRaises(ValueError):
+            validate_hosts({'hostname': 'a.com'})
+
+    def test_rejects_bad_port(self):
+        with self.assertRaises(ValueError):
+            validate_hosts([{'hostname': 'a.com', 'port': 99999}])
+
+    def test_rejects_bad_host_key(self):
+        with self.assertRaises(ValueError):
+            validate_hosts([{'hostname': 'a.com', 'host_key': 'ssh-dss AAAA'}])
+
+    def test_rejects_non_string_user_fields(self):
+        with self.assertRaises(ValueError):
+            validate_hosts([{'hostname': 'a.com', 'username': 42}])
+
+    def test_rejects_too_many_hosts(self):
+        with self.assertRaises(ValueError):
+            validate_hosts([{'hostname': 'h{}.com'.format(i)}
+                            for i in range(201)])
+
+    def test_empty_list_is_valid(self):
+        self.assertEqual(validate_hosts([]), [])
+
+
+class TestValidateSettings(unittest.TestCase):
+
+    def test_accepts_known_settings(self):
+        result = validate_settings({
+            'font_size': 14, 'background': '#000000', 'foreground': '#ffffff',
+            'cursor': '#00ff00', 'cursor_blink': True, 'encoding': 'utf-8',
+            'term': 'xterm-256color', 'key_source': 'stored',
+            'last_hostname': 'nas.lan', 'last_username': 'ryan',
+            'last_port': 2222,
+        })
+        self.assertEqual(result['font_size'], 14)
+        self.assertEqual(result['key_source'], 'stored')
+        self.assertEqual(result['last_port'], 2222)
+
+    def test_drops_secrets_and_unknown_keys(self):
+        result = validate_settings({
+            'password': 'hunter2', 'credential': 'x', 'totp': '123456',
+            'passphrase': 'y', 'privatekey': 'z', 'font_size': 12,
+        })
+        self.assertEqual(result, {'font_size': 12})
+
+    def test_rejects_non_mapping(self):
+        with self.assertRaises(ValueError):
+            validate_settings(['font_size', 12])
+
+    def test_rejects_out_of_range_font_size(self):
+        for size in [0, 5, 200]:
+            with self.assertRaises(ValueError):
+                validate_settings({'font_size': size})
+
+    def test_rejects_bad_color(self):
+        for color in ['javascript:alert(1)', '#12', 'red;x', 123]:
+            with self.assertRaises(ValueError):
+                validate_settings({'background': color})
+
+    def test_accepts_named_and_hex_colors(self):
+        for color in ['black', 'white', '#fff', '#00ff00']:
+            self.assertEqual(
+                validate_settings({'background': color})['background'], color)
+
+    def test_rejects_bad_key_source(self):
+        with self.assertRaises(ValueError):
+            validate_settings({'key_source': 'somewhere-else'})
+
+    def test_rejects_bad_encoding(self):
+        with self.assertRaises(ValueError):
+            validate_settings({'encoding': 'not-a-real-encoding'})
+
+
+class TestRoundTrip(unittest.TestCase):
+
+    def setUp(self):
+        self.base = tempfile.mkdtemp()
+
+    def test_hosts_round_trip(self):
+        written = write_hosts(self.base, 'alice', [{'hostname': 'nas.lan'}])
+        self.assertEqual(read_hosts(self.base, 'alice'), written)
+
+    def test_settings_round_trip(self):
+        written = write_settings(self.base, 'alice', {'font_size': 16})
+        self.assertEqual(read_settings(self.base, 'alice'), written)
+        self.assertEqual(written, {'font_size': 16})
+
+    def test_read_missing_returns_empty(self):
+        self.assertEqual(read_hosts(self.base, 'nobody'), [])
+        self.assertEqual(read_settings(self.base, 'nobody'), {})
+
+    def test_read_corrupt_returns_empty(self):
+        user_dir = get_user_data_dir(self.base, 'alice')
+        os.makedirs(user_dir, mode=0o700)
+        with open(os.path.join(user_dir, 'hosts.json'), 'w') as f:
+            f.write('{not json at all')
+        self.assertEqual(read_hosts(self.base, 'alice'), [])
+
+    def test_read_wrong_shape_returns_empty(self):
+        user_dir = get_user_data_dir(self.base, 'alice')
+        os.makedirs(user_dir, mode=0o700)
+        with open(os.path.join(user_dir, 'hosts.json'), 'w') as f:
+            json.dump({'version': 1, 'hosts': 'not-a-list'}, f)
+        self.assertEqual(read_hosts(self.base, 'alice'), [])
+
+    def test_written_file_has_version_and_mode(self):
+        write_hosts(self.base, 'alice', [{'hostname': 'nas.lan'}])
+        path = os.path.join(get_user_data_dir(self.base, 'alice'), 'hosts.json')
+        with open(path) as f:
+            raw = json.load(f)
+        self.assertEqual(raw['version'], SCHEMA_VERSION)
+        self.assertIsInstance(raw['hosts'], list)
+        mode = stat.S_IMODE(os.stat(path).st_mode)
+        self.assertEqual(mode, 0o600)
+
+    def test_invalid_write_leaves_previous_data(self):
+        write_hosts(self.base, 'alice', [{'hostname': 'good.lan'}])
+        with self.assertRaises(ValueError):
+            write_hosts(self.base, 'alice', [{'hostname': 'bad', 'port': 0}])
+        stored = read_hosts(self.base, 'alice')
+        self.assertEqual(len(stored), 1)
+        self.assertEqual(stored[0]['hostname'], 'good.lan')
+
+    def test_write_leaves_no_temp_files(self):
+        write_hosts(self.base, 'alice', [{'hostname': 'nas.lan'}])
+        entries = os.listdir(get_user_data_dir(self.base, 'alice'))
+        self.assertEqual(sorted(entries), ['hosts.json'])

--- a/webssh/handler.py
+++ b/webssh/handler.py
@@ -741,14 +741,26 @@ class UserDataMixin(object):
             raise tornado.web.HTTPError(400, 'Invalid username.')
         return username
 
-    def get_json_body(self, key, default):
+    def get_json_body(self, key):
         try:
             data = json.loads(self.request.body.decode('utf-8'))
         except (ValueError, UnicodeDecodeError):
             raise tornado.web.HTTPError(400, 'Malformed JSON body.')
         if not isinstance(data, dict):
             raise tornado.web.HTTPError(400, 'Body must be a JSON object.')
-        return data.get(key, default)
+        if key not in data:
+            raise tornado.web.HTTPError(
+                400, 'Missing "{}" key.'.format(key))
+        return data[key]
+
+    def write_error(self, status_code, **kwargs):
+        reason = self._reason
+        exc_info = kwargs.get('exc_info')
+        if exc_info:
+            log_message = getattr(exc_info[1], 'log_message', None)
+            if log_message:
+                reason = log_message
+        self.finish({'error': reason})
 
 
 class UserHostsHandler(UserDataMixin, MixinHandler,
@@ -765,7 +777,7 @@ class UserHostsHandler(UserDataMixin, MixinHandler,
     def put(self):
         self.check_feature_enabled()
         username = self.get_auth_username()
-        hosts = self.get_json_body('hosts', [])
+        hosts = self.get_json_body('hosts')
         try:
             stored = user_data.write_hosts(self.user_data_dir, username, hosts)
         except ValueError as exc:
@@ -786,7 +798,7 @@ class UserSettingsHandler(UserDataMixin, MixinHandler,
     def put(self):
         self.check_feature_enabled()
         username = self.get_auth_username()
-        settings = self.get_json_body('settings', {})
+        settings = self.get_json_body('settings')
         try:
             stored = user_data.write_settings(
                 self.user_data_dir, username, settings)

--- a/webssh/handler.py
+++ b/webssh/handler.py
@@ -344,6 +344,7 @@ class IndexHandler(MixinHandler, tornado.web.RequestHandler):
 
     def initialize(self, loop, policy, host_keys_settings, allowed_hosts=None,
                    user_key_dir='', user_header='X-Authentik-Username',
+                   user_data_dir='', user_hosts_enabled=False,
                    live_config=None):
         super(IndexHandler, self).initialize(loop)
         self.live_config = live_config if live_config is not None else {}
@@ -354,6 +355,8 @@ class IndexHandler(MixinHandler, tornado.web.RequestHandler):
             'allowed_hosts', allowed_hosts) or []
         self.user_key_dir = user_key_dir
         self.user_header = user_header
+        self.user_data_dir = user_data_dir
+        self.user_hosts_enabled = user_hosts_enabled
         self.ssh_client = self.get_ssh_client()
         self.debug = self.settings.get('debug', False)
         self.font = self.settings.get('font', '')
@@ -421,10 +424,30 @@ class IndexHandler(MixinHandler, tornado.web.RequestHandler):
                             hostname, port)
                     )
 
+    def get_user_hosts(self):
+        if not self.user_hosts_enabled or not self.user_data_dir:
+            return []
+        username = self.request.headers.get(self.user_header, '')
+        if not username:
+            return []
+        try:
+            return user_data.read_hosts(self.user_data_dir, username)
+        except ValueError:
+            return []
+
+    def get_effective_hosts(self):
+        admin = self.allowed_hosts
+        seen = set((h['hostname'], h['port']) for h in admin)
+        merged = list(admin)
+        for host in self.get_user_hosts():
+            if (host['hostname'], host['port']) not in seen:
+                merged.append(host)
+        return merged
+
     def check_allowed_hosts(self, hostname, port):
         if not self.allowed_hosts:
             return
-        for host in self.allowed_hosts:
+        for host in self.get_effective_hosts():
             if host['hostname'] == hostname and host['port'] == port:
                 return
         raise tornado.web.HTTPError(
@@ -432,9 +455,7 @@ class IndexHandler(MixinHandler, tornado.web.RequestHandler):
         )
 
     def load_configured_host_key(self, hostname, port):
-        if not self.allowed_hosts:
-            return
-        for host in self.allowed_hosts:
+        for host in self.get_effective_hosts():
             if host['hostname'] == hostname and host['port'] == port:
                 for key_str in host.get('host_keys', []):
                     self._add_host_key(hostname, port, key_str)
@@ -617,12 +638,24 @@ class IndexHandler(MixinHandler, tornado.web.RequestHandler):
             except ValueError:
                 pass
 
+        user_hosts = self.get_user_hosts()
+        user_settings = {}
+        if self.user_hosts_enabled and auth_username:
+            try:
+                user_settings = user_data.read_settings(
+                    self.user_data_dir, auth_username)
+            except ValueError:
+                user_settings = {}
+
         self.render('index.html', debug=self.debug, font=self.font,
                     allowed_hosts=self.allowed_hosts,
                     user_key_enabled=user_key_enabled,
                     has_stored_key=has_key,
                     public_key=public_key,
                     auth_username=auth_username,
+                    user_hosts_enabled=self.user_hosts_enabled,
+                    user_hosts=user_hosts,
+                    user_settings=user_settings,
                     version=__version__)
 
     @tornado.gen.coroutine

--- a/webssh/handler.py
+++ b/webssh/handler.py
@@ -875,6 +875,18 @@ class UserSettingsHandler(UserDataMixin, MixinHandler,
         self.write({'settings': stored})
 
 
+class SettingsPaneHandler(UserDataMixin, MixinHandler,
+                          tornado.web.RequestHandler):
+
+    def get(self):
+        if not self.user_hosts_enabled or not self.user_data_dir:
+            raise tornado.web.HTTPError(404)
+        username = self.get_auth_username()
+        self.render('settings.html',
+                    auth_username=username,
+                    admin_hosts=self.allowed_hosts)
+
+
 class WsockHandler(MixinHandler, tornado.websocket.WebSocketHandler):
 
     def initialize(self, loop):

--- a/webssh/handler.py
+++ b/webssh/handler.py
@@ -440,7 +440,17 @@ class IndexHandler(MixinHandler, tornado.web.RequestHandler):
         seen = set((h['hostname'], h['port']) for h in admin)
         merged = list(admin)
         for host in self.get_user_hosts():
-            if (host['hostname'], host['port']) not in seen:
+            if not isinstance(host, dict):
+                logging.warning(
+                    'Skipping malformed user host entry: {!r}'.format(host))
+                continue
+            hostname = host.get('hostname')
+            port = host.get('port')
+            if hostname is None or port is None:
+                logging.warning(
+                    'Skipping malformed user host entry: {!r}'.format(host))
+                continue
+            if (hostname, port) not in seen:
                 merged.append(host)
         return merged
 

--- a/webssh/handler.py
+++ b/webssh/handler.py
@@ -378,10 +378,33 @@ class IndexHandler(MixinHandler, tornado.web.RequestHandler):
     def get_ssh_client(self):
         ssh = SSHClient()
         ssh._system_host_keys = self.host_keys_settings['system_host_keys']
-        ssh._host_keys = self.host_keys_settings['host_keys']
+        host_keys = self.host_keys_settings['host_keys']
+        if self.user_hosts_enabled:
+            # User-supplied host entries can contribute host key pins, and
+            # paramiko's HostKeys.add() mutates the store in place (replacing
+            # the key of a matching entry). Sharing the process-wide store
+            # would let one user's pin leak into every other request, both
+            # widening the reject-policy allowlist and downgrading the
+            # administrator's pins. Give this request its own deep-enough
+            # copy: new HostKeys, new HostKeyEntry objects, new hostname
+            # lists. The PKey objects themselves are never mutated, only
+            # rebound, so they can be shared.
+            host_keys = self.copy_host_keys(host_keys)
+        ssh._host_keys = host_keys
         ssh._host_keys_filename = self.host_keys_settings['host_keys_filename']
         ssh.set_missing_host_key_policy(self.policy)
         return ssh
+
+    @staticmethod
+    def copy_host_keys(host_keys):
+        """Return a private copy of a paramiko HostKeys store."""
+        private = paramiko.hostkeys.HostKeys()
+        for entry in host_keys._entries:
+            private._entries.append(
+                paramiko.hostkeys.HostKeyEntry(
+                    list(entry.hostnames), entry.key)
+            )
+        return private
 
     def get_privatekey(self):
         name = 'privatekey'

--- a/webssh/handler.py
+++ b/webssh/handler.py
@@ -18,6 +18,7 @@ from webssh.utils import (
     is_valid_encoding
 )
 from webssh.worker import Worker, recycle_worker, clients
+from webssh import user_data
 from webssh import user_keys
 from webssh._version import __version__
 
@@ -708,6 +709,90 @@ class UserKeyHandler(MixinHandler, tornado.web.RequestHandler):
             'username': username,
             'public_key': public_key
         })
+
+
+class UserDataMixin(object):
+
+    def initialize(self, loop, user_data_dir, user_header,
+                   user_hosts_enabled, allowed_hosts=None, live_config=None):
+        super(UserDataMixin, self).initialize(loop)
+        self.user_data_dir = user_data_dir
+        self.user_header = user_header
+        self.user_hosts_enabled = user_hosts_enabled
+        self.live_config = live_config if live_config is not None else {}
+        self._allowed_hosts = allowed_hosts or []
+
+    @property
+    def allowed_hosts(self):
+        return self.live_config.get('allowed_hosts', self._allowed_hosts) or []
+
+    def check_feature_enabled(self):
+        if not self.user_hosts_enabled or not self.user_data_dir:
+            raise tornado.web.HTTPError(
+                403, 'User host management is not enabled.')
+
+    def get_auth_username(self):
+        username = self.request.headers.get(self.user_header, '')
+        if not username:
+            raise tornado.web.HTTPError(401, 'No authenticated user found.')
+        try:
+            user_keys.sanitize_username(username)
+        except ValueError:
+            raise tornado.web.HTTPError(400, 'Invalid username.')
+        return username
+
+    def get_json_body(self, key, default):
+        try:
+            data = json.loads(self.request.body.decode('utf-8'))
+        except (ValueError, UnicodeDecodeError):
+            raise tornado.web.HTTPError(400, 'Malformed JSON body.')
+        if not isinstance(data, dict):
+            raise tornado.web.HTTPError(400, 'Body must be a JSON object.')
+        return data.get(key, default)
+
+
+class UserHostsHandler(UserDataMixin, MixinHandler,
+                       tornado.web.RequestHandler):
+
+    def get(self):
+        self.check_feature_enabled()
+        username = self.get_auth_username()
+        self.write({
+            'admin_hosts': self.allowed_hosts,
+            'user_hosts': user_data.read_hosts(self.user_data_dir, username),
+        })
+
+    def put(self):
+        self.check_feature_enabled()
+        username = self.get_auth_username()
+        hosts = self.get_json_body('hosts', [])
+        try:
+            stored = user_data.write_hosts(self.user_data_dir, username, hosts)
+        except ValueError as exc:
+            raise tornado.web.HTTPError(400, str(exc))
+        self.write({'user_hosts': stored})
+
+
+class UserSettingsHandler(UserDataMixin, MixinHandler,
+                          tornado.web.RequestHandler):
+
+    def get(self):
+        self.check_feature_enabled()
+        username = self.get_auth_username()
+        self.write({
+            'settings': user_data.read_settings(self.user_data_dir, username),
+        })
+
+    def put(self):
+        self.check_feature_enabled()
+        username = self.get_auth_username()
+        settings = self.get_json_body('settings', {})
+        try:
+            stored = user_data.write_settings(
+                self.user_data_dir, username, settings)
+        except ValueError as exc:
+            raise tornado.web.HTTPError(400, str(exc))
+        self.write({'settings': stored})
 
 
 class WsockHandler(MixinHandler, tornado.websocket.WebSocketHandler):

--- a/webssh/handler.py
+++ b/webssh/handler.py
@@ -778,10 +778,23 @@ class UserHostsHandler(UserDataMixin, MixinHandler,
         self.check_feature_enabled()
         username = self.get_auth_username()
         hosts = self.get_json_body('hosts')
+        # Validate first: ValueErrors from validation describe the
+        # caller's own input (bad hostname, bad port, ...) and are safe
+        # to return to the client as-is.
+        try:
+            user_data.validate_hosts(hosts)
+        except ValueError as exc:
+            raise tornado.web.HTTPError(400, str(exc))
+        # A failure here is about server state (disk permissions, a bad
+        # data directory, ...), never the client's input. That detail
+        # must never reach the client -- log it and return a generic 500.
         try:
             stored = user_data.write_hosts(self.user_data_dir, username, hosts)
         except ValueError as exc:
-            raise tornado.web.HTTPError(400, str(exc))
+            logging.error(
+                'Failed to write hosts for user {!r}: {}'.format(
+                    username, exc))
+            raise tornado.web.HTTPError(500, 'Failed to save hosts.')
         self.write({'user_hosts': stored})
 
 
@@ -799,11 +812,23 @@ class UserSettingsHandler(UserDataMixin, MixinHandler,
         self.check_feature_enabled()
         username = self.get_auth_username()
         settings = self.get_json_body('settings')
+        # Validate first: ValueErrors from validation describe the
+        # caller's own input and are safe to return to the client as-is.
+        try:
+            user_data.validate_settings(settings)
+        except ValueError as exc:
+            raise tornado.web.HTTPError(400, str(exc))
+        # A failure here is about server state, never the client's input.
+        # That detail must never reach the client -- log it and return a
+        # generic 500.
         try:
             stored = user_data.write_settings(
                 self.user_data_dir, username, settings)
         except ValueError as exc:
-            raise tornado.web.HTTPError(400, str(exc))
+            logging.error(
+                'Failed to write settings for user {!r}: {}'.format(
+                    username, exc))
+            raise tornado.web.HTTPError(500, 'Failed to save settings.')
         self.write({'settings': stored})
 
 

--- a/webssh/main.py
+++ b/webssh/main.py
@@ -10,7 +10,7 @@ from tornado.options import options
 from webssh import handler
 from webssh.handler import (
     IndexHandler, WsockHandler, NotFoundHandler, UserKeyHandler,
-    UserHostsHandler, UserSettingsHandler
+    UserHostsHandler, UserSettingsHandler, SettingsPaneHandler
 )
 from webssh.policy import get_policy_class
 from webssh.settings import (
@@ -64,6 +64,7 @@ def make_handlers(loop, options, live_config=None):
         (r'/ws', WsockHandler, dict(loop=loop)),
         (r'/api/hosts', UserHostsHandler, user_data_kwargs),
         (r'/api/settings', UserSettingsHandler, user_data_kwargs),
+        (r'/settings-pane', SettingsPaneHandler, user_data_kwargs),
     ]
 
     if user_key_dir:

--- a/webssh/main.py
+++ b/webssh/main.py
@@ -9,7 +9,8 @@ from tornado.ioloop import PeriodicCallback
 from tornado.options import options
 from webssh import handler
 from webssh.handler import (
-    IndexHandler, WsockHandler, NotFoundHandler, UserKeyHandler
+    IndexHandler, WsockHandler, NotFoundHandler, UserKeyHandler,
+    UserHostsHandler, UserSettingsHandler
 )
 from webssh.policy import get_policy_class
 from webssh.settings import (
@@ -35,6 +36,18 @@ def make_handlers(loop, options, live_config=None):
     user_key_dir = options.userkeydir
     user_header = options.userheader
 
+    user_data_dir = get_user_data_dir_setting(options)
+    user_hosts_enabled = bool(options.user_hosts and user_data_dir)
+
+    user_data_kwargs = dict(
+        loop=loop,
+        user_data_dir=user_data_dir,
+        user_header=user_header,
+        user_hosts_enabled=user_hosts_enabled,
+        allowed_hosts=allowed_hosts,
+        live_config=live_config
+    )
+
     index_kwargs = dict(
         loop=loop, policy=policy,
         host_keys_settings=host_keys_settings,
@@ -46,7 +59,9 @@ def make_handlers(loop, options, live_config=None):
 
     handlers = [
         (r'/', IndexHandler, index_kwargs),
-        (r'/ws', WsockHandler, dict(loop=loop))
+        (r'/ws', WsockHandler, dict(loop=loop)),
+        (r'/api/hosts', UserHostsHandler, user_data_kwargs),
+        (r'/api/settings', UserSettingsHandler, user_data_kwargs),
     ]
 
     if user_key_dir:
@@ -169,6 +184,23 @@ def start_config_watcher(config_path, live_config, host_keys_settings,
     return watcher
 
 
+def check_user_hosts_configuration(user_hosts, user_data_dir, tdstream=''):
+    """Warn (and validate the directory) when user_hosts is enabled.
+
+    Split out of main() so the "enabled but unconfigured" warning can be
+    exercised directly in tests without going through the full startup path.
+    """
+    if not user_hosts:
+        return
+    if not user_data_dir:
+        logging.warning(
+            'user_hosts is enabled but no userdatadir or userkeydir '
+            'is configured, so user host management is disabled.'
+        )
+        return
+    check_user_data_dir(user_data_dir, tdstream)
+
+
 def main():
     options.parse_command_line()
     if not options.config and os.path.isfile(DEFAULT_CONFIG_PATH):
@@ -178,8 +210,8 @@ def main():
     check_encoding_setting(options.encoding)
     check_user_key_dir(options.userkeydir, options.tdstream)
     user_data_dir = get_user_data_dir_setting(options)
-    if options.user_hosts:
-        check_user_data_dir(user_data_dir, options.tdstream)
+    check_user_hosts_configuration(
+        options.user_hosts, user_data_dir, options.tdstream)
     loop = tornado.ioloop.IOLoop.current()
     live_config = {}
     app = make_app(make_handlers(loop, options, live_config),

--- a/webssh/main.py
+++ b/webssh/main.py
@@ -16,7 +16,8 @@ from webssh.settings import (
     get_app_settings,  get_host_keys_settings, get_policy_setting,
     get_ssl_context, get_server_settings, check_encoding_setting,
     get_allowed_hosts_setting, check_user_key_dir, apply_config_settings,
-    load_config_file, parse_allowed_hosts
+    load_config_file, parse_allowed_hosts, get_user_data_dir_setting,
+    check_user_data_dir
 )
 
 
@@ -176,6 +177,9 @@ def main():
     apply_config_settings(options)
     check_encoding_setting(options.encoding)
     check_user_key_dir(options.userkeydir, options.tdstream)
+    user_data_dir = get_user_data_dir_setting(options)
+    if options.user_hosts:
+        check_user_data_dir(user_data_dir, options.tdstream)
     loop = tornado.ioloop.IOLoop.current()
     live_config = {}
     app = make_app(make_handlers(loop, options, live_config),

--- a/webssh/main.py
+++ b/webssh/main.py
@@ -54,6 +54,8 @@ def make_handlers(loop, options, live_config=None):
         allowed_hosts=allowed_hosts,
         user_key_dir=user_key_dir,
         user_header=user_header,
+        user_data_dir=user_data_dir,
+        user_hosts_enabled=user_hosts_enabled,
         live_config=live_config
     )
 

--- a/webssh/settings.py
+++ b/webssh/settings.py
@@ -60,6 +60,11 @@ define('userkeydir', default='',
        help='Directory to store per-user SSH key pairs')
 define('userheader', default='X-Authentik-Username',
        help='HTTP header with authenticated username')
+define('userdatadir', default='',
+       help='Directory for per-user hosts and settings '
+            '(defaults to userkeydir)')
+define('user_hosts', type=bool, default=False,
+       help='Allow authenticated users to manage their own host list')
 define('version', type=bool, help='Show version information',
        callback=print_version)
 
@@ -364,6 +369,10 @@ def apply_config_settings(options):
         options.userkeydir = config['userkeydir']
     if options.userheader == 'X-Authentik-Username' and 'userheader' in config:
         options.userheader = config['userheader']
+    if not options.userdatadir and 'userdatadir' in config:
+        options.userdatadir = config['userdatadir']
+    if not options.user_hosts and 'user_hosts' in config:
+        options.user_hosts = bool(config['user_hosts'])
     if 'idle_timeout' in config:
         raw = config['idle_timeout']
         try:
@@ -422,4 +431,34 @@ def check_user_key_dir(user_key_dir, tdstream=''):
     if not os.path.isdir(user_key_dir):
         raise ValueError(
             'User key directory {!r} is not a directory'.format(user_key_dir)
+        )
+
+
+def get_user_data_dir_setting(options):
+    return options.userdatadir or options.userkeydir or ''
+
+
+def check_user_data_dir(user_data_dir, tdstream=''):
+    if not user_data_dir:
+        return
+    if not tdstream:
+        logging.warning(
+            'SECURITY WARNING: user_hosts is enabled but no trusted_proxies '
+            'configured. The user header can be spoofed by any client.'
+        )
+    try:
+        os.makedirs(user_data_dir, mode=0o700, exist_ok=True)
+    except PermissionError:
+        raise ValueError(
+            'Cannot create user data directory {!r}: permission denied. '
+            'Create the directory manually or run with appropriate '
+            'permissions.'.format(user_data_dir)
+        )
+    except (FileExistsError, NotADirectoryError):
+        raise ValueError(
+            'User data directory {!r} is not a directory'.format(user_data_dir)
+        )
+    if not os.path.isdir(user_data_dir):
+        raise ValueError(
+            'User data directory {!r} is not a directory'.format(user_data_dir)
         )

--- a/webssh/settings.py
+++ b/webssh/settings.py
@@ -283,6 +283,41 @@ def _validate_host_key(host_key, hostname):
         )
 
 
+def parse_host_entry(entry):
+    if not isinstance(entry, dict):
+        raise ValueError('Each host entry must be a mapping')
+    if 'hostname' not in entry:
+        raise ValueError('Each host entry must have a "hostname" field')
+    raw_keys = entry.get('host_key', [])
+    if isinstance(raw_keys, str):
+        raw_keys = [raw_keys] if raw_keys else []
+    elif not isinstance(raw_keys, list):
+        raise ValueError(
+            'host_key for {!r} must be a string or list'.format(
+                entry['hostname'])
+        )
+    for k in raw_keys:
+        _validate_host_key(k, entry['hostname'])
+    try:
+        port = int(entry.get('port', 22))
+    except (TypeError, ValueError):
+        raise ValueError(
+            'Invalid port {!r} for host {!r}; must be 1-65535'.format(
+                entry.get('port'), entry['hostname'])
+        )
+    if port < 1 or port > 65535:
+        raise ValueError(
+            'Invalid port {!r} for host {!r}; must be 1-65535'.format(
+                port, entry['hostname'])
+        )
+    return {
+        'name': entry.get('name', entry['hostname']),
+        'hostname': entry['hostname'],
+        'port': port,
+        'host_keys': raw_keys,
+    }
+
+
 def parse_allowed_hosts(data):
     if 'hosts' not in data:
         return []
@@ -293,37 +328,7 @@ def parse_allowed_hosts(data):
             'Config file "hosts" must be a non-empty list'
         )
 
-    result = []
-    for entry in hosts:
-        if not isinstance(entry, dict):
-            raise ValueError('Each host entry must be a mapping')
-        if 'hostname' not in entry:
-            raise ValueError('Each host entry must have a "hostname" field')
-        raw_keys = entry.get('host_key', [])
-        if isinstance(raw_keys, str):
-            raw_keys = [raw_keys] if raw_keys else []
-        elif not isinstance(raw_keys, list):
-            raise ValueError(
-                'host_key for {!r} must be a string or list'.format(
-                    entry['hostname'])
-            )
-        for k in raw_keys:
-            _validate_host_key(k, entry['hostname'])
-        port = int(entry.get('port', 22))
-        if port < 1 or port > 65535:
-            raise ValueError(
-                'Invalid port {!r} for host {!r}; must be 1-65535'.format(
-                    port, entry['hostname'])
-            )
-        host = {
-            'name': entry.get('name', entry['hostname']),
-            'hostname': entry['hostname'],
-            'port': port,
-            'host_keys': raw_keys,
-        }
-        result.append(host)
-
-    return result
+    return [parse_host_entry(entry) for entry in hosts]
 
 
 def load_allowed_hosts(filepath):

--- a/webssh/static/css/main.css
+++ b/webssh/static/css/main.css
@@ -865,6 +865,10 @@ body.has-tabs .terminal-pane .xterm.fullscreen {
   border-top: 1px solid var(--border-subtle);
 }
 
+/* .btn-connect defaults to flex:1 for the connect form's .actions row;
+   in the settings footer that stretches Save across the full width. */
+.settings-footer .btn-connect { flex: none; }
+
 .settings-status { font-size: 0.85em; opacity: 0.75; }
 .settings-status.error { color: var(--danger); opacity: 1; }
 

--- a/webssh/static/css/main.css
+++ b/webssh/static/css/main.css
@@ -867,3 +867,5 @@ body.has-tabs .terminal-pane .xterm.fullscreen {
 
 .settings-status { font-size: 0.85em; opacity: 0.75; }
 .settings-status.error { color: var(--danger); opacity: 1; }
+
+.input-error { border-color: var(--danger) !important; background: var(--danger-dim); }

--- a/webssh/static/css/main.css
+++ b/webssh/static/css/main.css
@@ -793,3 +793,77 @@ body.has-tabs .terminal-pane .xterm.fullscreen {
     border-radius: var(--radius);
   }
 }
+
+/* --- Settings pane --- */
+.settings-pane {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow: hidden;
+  color: inherit;
+}
+
+.settings-header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.settings-title { font-weight: 600; letter-spacing: 0.04em; }
+.settings-user { opacity: 0.7; font-size: 0.85em; }
+
+.settings-tabs { display: flex; gap: 4px; padding: 8px 16px 0; }
+
+.settings-tab {
+  background: none;
+  border: none;
+  border-bottom: 2px solid transparent;
+  padding: 6px 12px;
+  color: inherit;
+  opacity: 0.6;
+  cursor: pointer;
+}
+
+.settings-tab.active { opacity: 1; border-bottom-color: currentColor; }
+
+.settings-body { flex: 1; overflow-y: auto; padding: 16px; }
+.settings-section { display: none; }
+.settings-section.active { display: block; }
+
+.settings-subhead {
+  text-transform: uppercase;
+  font-size: 0.75em;
+  letter-spacing: 0.08em;
+  opacity: 0.6;
+  margin: 16px 0 8px;
+}
+
+.settings-table { width: 100%; border-collapse: collapse; }
+.settings-table td { padding: 4px; vertical-align: top; }
+.settings-table tr.admin-host td { opacity: 0.55; padding: 6px 4px; }
+
+.host-badge {
+  font-size: 0.7em;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  border: 1px solid currentColor;
+  border-radius: 3px;
+  padding: 1px 5px;
+  opacity: 0.8;
+}
+
+.settings-checkbox { display: flex; align-items: center; gap: 8px; }
+
+.settings-footer {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 12px;
+  padding: 12px 16px;
+  border-top: 1px solid var(--border-subtle);
+}
+
+.settings-status { font-size: 0.85em; opacity: 0.75; }
+.settings-status.error { color: var(--danger); opacity: 1; }

--- a/webssh/static/css/main.css
+++ b/webssh/static/css/main.css
@@ -509,13 +509,13 @@ textarea.pubkey-display:focus {
 }
 
 .btn-generate {
-  padding: 6px 14px;
+  padding: 8px 16px;
   background: var(--bg-elevated);
   color: var(--text-secondary);
   border: 1px solid var(--border-subtle);
   border-radius: 6px;
   font-family: var(--font-mono);
-  font-size: 11px;
+  font-size: 13px;
   font-weight: 500;
   cursor: pointer;
   transition: all 0.15s;
@@ -692,20 +692,27 @@ textarea.pubkey-display:focus {
   background: var(--danger-dim);
 }
 
-#new-tab-btn {
+#new-tab-btn,
+#settings-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   width: 36px;
   height: 36px;
+  padding: 0;
   border: none;
   background: none;
   color: var(--accent);
   font-family: var(--font-mono);
-  font-size: 18px;
+  font-size: 22px;
+  line-height: 1;
   cursor: pointer;
   flex-shrink: 0;
   transition: background 0.1s;
 }
 
-#new-tab-btn:hover {
+#new-tab-btn:hover,
+#settings-btn:hover {
   background: var(--accent-dim);
 }
 

--- a/webssh/static/js/main.js
+++ b/webssh/static/js/main.js
@@ -872,14 +872,63 @@ jQuery(function($){
   }
 
 
+  function build_hostname_select() {
+    return $('<select>')
+      .attr('id', 'hostname')
+      .attr('name', 'hostname')
+      .addClass('field-input')
+      .attr('required', 'required');
+  }
+
+
+  function build_hostname_input() {
+    return $('<input>')
+      .attr('type', 'text')
+      .attr('id', 'hostname')
+      .attr('name', 'hostname')
+      .addClass('field-input')
+      .attr('placeholder', 'host or host:port')
+      .attr('required', 'required')
+      .val('');
+  }
+
+
   function refresh_host_list() {
     if (!user_hosts_enabled) return;
     $.get('/api/hosts').done(function(data) {
-      var select = $('#hostname');
-      if (!select.is('select')) return;
-      var current = select.val();
-      select.empty();
-      var groups = [data.admin_hosts || [], data.user_hosts || []];
+      var admin_hosts = data.admin_hosts || [];
+      var user_hosts = data.user_hosts || [];
+      var total = admin_hosts.length + user_hosts.length;
+      var el = $('#hostname');
+      var is_select = el.is('select');
+      var current = el.val();
+
+      if (total > 0 && !is_select) {
+        // Upgrade the plain text input into a dropdown now that there is
+        // something to choose from. Built via jQuery DOM construction
+        // (not string-concatenated HTML) to keep this XSS-safe like the
+        // option-building code below.
+        var new_select = build_hostname_select();
+        el.replaceWith(new_select);
+        el = new_select;
+        is_select = true;
+        // Keep this in lockstep with index.html's identical
+        // allowed_hosts-or-user_hosts condition on #port's readonly attr.
+        $('#port').attr('readonly', 'readonly');
+      } else if (total === 0 && is_select) {
+        // Downgrade back to free text; nothing left to choose from and an
+        // empty <select> would leave the user with no way to type a host.
+        var new_input = build_hostname_input();
+        el.replaceWith(new_input);
+        el = new_input;
+        is_select = false;
+        $('#port').removeAttr('readonly');
+      }
+
+      if (!is_select) return;
+
+      el.empty();
+      var groups = [admin_hosts, user_hosts];
       for (var g = 0; g < groups.length; g++) {
         for (var i = 0; i < groups[g].length; i++) {
           var host = groups[g][i];
@@ -891,11 +940,11 @@ jQuery(function($){
             option.attr('data-username', host.username || '');
             option.attr('data-command', host.default_command || '');
           }
-          select.append(option);
+          el.append(option);
         }
       }
-      if (current) select.val(current);
-      select.trigger('change');
+      if (current) el.val(current);
+      el.trigger('change');
     });
   }
 
@@ -1540,8 +1589,12 @@ jQuery(function($){
     update_advanced_summary();
   });
 
-  // Auto-populate port and restore default command when hostname changes
-  $('#hostname').on('change', function() {
+  // Auto-populate port and restore default command when hostname changes.
+  // Delegated on the form (rather than bound directly to #hostname) because
+  // refresh_host_list() may replace the #hostname element outright when it
+  // upgrades between a plain text input and a <select>; a direct binding
+  // would be lost when that happens.
+  $(form_id).on('change', '#hostname', function() {
     var port;
     if ($(this).is('select')) {
       port = $(this).find(':selected').data('port');

--- a/webssh/static/js/main.js
+++ b/webssh/static/js/main.js
@@ -406,6 +406,14 @@ jQuery(function($){
         url: '/api/settings', type: 'PUT', contentType: 'application/json',
         headers: {'X-Xsrftoken': get_xsrf_token()},
         data: JSON.stringify({settings: user_settings})
+      }).fail(function(xhr) {
+        // Silent failure here means preferences quietly revert on the next
+        // page load (the roamed value wins over localStorage), so make it
+        // visible.
+        var detail = xhr && xhr.status ? String(xhr.status) : 'network error';
+        var message = 'Could not save preferences (' + detail + ').';
+        console.warn(message);
+        show_status_text(message);
       });
     }
   };
@@ -494,11 +502,28 @@ jQuery(function($){
   }
 
 
+  // The username carried by the currently selected host option, if any.
+  function selected_host_username() {
+    var el = $('#hostname');
+    if (!el.is('select')) return '';
+    return el.find('option:selected').attr('data-username') || '';
+  }
+
+
   function restore_items(names) {
     var i, name, value;
 
     for (i = 0; i < names.length; i++) {
       name = names[i];
+      // 'hostname' is restored before 'username' and its change handler
+      // fills #username from the selected host's data-username. That
+      // host-specific username must win over the roamed/stored one, which
+      // would otherwise clobber it here. A free-text hostname (or a host
+      // with no saved username) carries no data-username, so the roamed
+      // last_username still applies there.
+      if (name === 'username' && selected_host_username()) {
+        continue;
+      }
       value = null;
       if (user_hosts_enabled && ROAMING_FIELDS[name]) {
         var roamed = user_settings[ROAMING_FIELDS[name]];
@@ -792,8 +817,9 @@ jQuery(function($){
 
   status.on('click', dismiss_status);
 
-  function log_status(text, to_populate) {
-    console.log(text);
+  // Set the status banner text without touching the waiter or the form
+  // container, so background failures can report themselves at any time.
+  function show_status_text(text) {
     if (text) {
       status.empty()
         .append($('<span>').text(text))
@@ -802,6 +828,11 @@ jQuery(function($){
     } else {
       status.empty().removeClass('visible');
     }
+  }
+
+  function log_status(text, to_populate) {
+    console.log(text);
+    show_status_text(text);
 
     if (to_populate && validated_form_data) {
       populate_form(validated_form_data);

--- a/webssh/static/js/main.js
+++ b/webssh/static/js/main.js
@@ -390,16 +390,66 @@ jQuery(function($){
 
   // ===================== Utility Functions =====================
 
+  var prefs = {
+    pending: null,
+    timer: null,
+
+    get: function(name) {
+      if (user_hosts_enabled && user_settings[name] !== undefined) {
+        return user_settings[name];
+      }
+      return window.localStorage.getItem(name);
+    },
+
+    set: function(name, value) {
+      window.localStorage.setItem(name, value);
+      if (!user_hosts_enabled) return;
+      user_settings[name] = value;
+      this.schedule();
+    },
+
+    schedule: function() {
+      var self = this;
+      if (this.timer) window.clearTimeout(this.timer);
+      this.timer = window.setTimeout(function() { self.flush(); }, 1000);
+    },
+
+    flush: function() {
+      if (!user_hosts_enabled) return;
+      this.timer = null;
+      $.ajax({
+        url: '/api/settings', type: 'PUT', contentType: 'application/json',
+        headers: {'X-Xsrftoken': get_xsrf_token()},
+        data: JSON.stringify({settings: user_settings})
+      });
+    }
+  };
+
+
+  var ROAMING_FIELDS = {
+    hostname: 'last_hostname',
+    username: 'last_username',
+    port: 'last_port'
+  };
+
+
   function store_items(names, data) {
     var i, name, value;
 
     for (i = 0; i < names.length; i++) {
       name = names[i];
       value = data.get(name);
-      if (value){
+      if (value) {
         window.localStorage.setItem(name, value);
+        if (ROAMING_FIELDS[name]) {
+          var stored = (name === 'port') ? window.parseInt(value, 10) : value;
+          if (name !== 'port' || stored > 0) {
+            user_settings[ROAMING_FIELDS[name]] = stored;
+          }
+        }
       }
     }
+    prefs.schedule();
   }
 
 
@@ -408,6 +458,21 @@ jQuery(function($){
     var port = data.get ? data.get('port') : data.port;
     if (!hostname) return null;
     return 'command:' + hostname + ':' + (port || '22');
+  }
+
+
+  function find_user_host(hostname, port) {
+    var match = null;
+    $('#hostname option').each(function() {
+      var option = $(this);
+      // Only user hosts carry data-command; admin hosts never do.
+      if (option.attr('data-command') === undefined) return;
+      if (option.attr('value') !== hostname) return;
+      if (String(option.attr('data-port')) !== String(port || 22)) return;
+      match = option;
+      return false;
+    });
+    return match;
   }
 
 
@@ -420,11 +485,17 @@ jQuery(function($){
     } else {
       window.localStorage.removeItem(key);
     }
+    // Server-side hosts own their own default_command, edited in Settings.
   }
 
 
   function restore_default_command(hostname, port) {
     if (!hostname) return;
+    var option = find_user_host(hostname, port);
+    if (option) {
+      $('#default-command').val(option.attr('data-command') || '');
+      return;
+    }
     var key = get_host_key({hostname: hostname, port: port});
     if (!key) return;
     var command = window.localStorage.getItem(key);
@@ -435,17 +506,93 @@ jQuery(function($){
   function restore_items(names) {
     var i, name, value;
 
-    for (i=0; i < names.length; i++) {
+    for (i = 0; i < names.length; i++) {
       name = names[i];
-      value = window.localStorage.getItem(name);
+      value = null;
+      if (user_hosts_enabled && ROAMING_FIELDS[name]) {
+        var roamed = user_settings[ROAMING_FIELDS[name]];
+        if (roamed !== undefined && roamed !== null && roamed !== '') {
+          value = String(roamed);
+        }
+      }
+      if (value === null) {
+        value = window.localStorage.getItem(name);
+      }
       if (value) {
-        var el = $('#'+name);
+        var el = $('#' + name);
         el.val(value);
         if (name === 'hostname' && el.is('select')) {
           el.trigger('change');
         }
       }
     }
+  }
+
+
+  function migrate_local_commands() {
+    if (!user_hosts_enabled) return;
+    if (window.localStorage.getItem('webssh_migrated_commands')) return;
+    if (migrate_local_commands.running) return;
+    migrate_local_commands.running = true;
+
+    var found = [];
+    for (var i = 0; i < window.localStorage.length; i++) {
+      var key = window.localStorage.key(i);
+      if (key && key.indexOf('command:') === 0) {
+        var parts = key.split(':');
+        found.push({
+          hostname: parts[1],
+          port: window.parseInt(parts[2], 10) || 22,
+          command: window.localStorage.getItem(key)
+        });
+      }
+    }
+    if (!found.length) {
+      window.localStorage.setItem('webssh_migrated_commands', '1');
+      migrate_local_commands.running = false;
+      return;
+    }
+    $.get('/api/hosts').done(function(data) {
+      var hosts = data.user_hosts || [];
+      var index = {};
+      for (var i = 0; i < hosts.length; i++) {
+        index[hosts[i].hostname + ':' + hosts[i].port] = hosts[i];
+      }
+      var changed = false;
+      for (var j = 0; j < found.length; j++) {
+        var match = index[found[j].hostname + ':' + found[j].port];
+        if (match && !match.default_command) {
+          match.default_command = found[j].command;
+          changed = true;
+        }
+      }
+      if (!changed) {
+        window.localStorage.setItem('webssh_migrated_commands', '1');
+        return;
+      }
+      var payload = [];
+      for (var k = 0; k < hosts.length; k++) {
+        payload.push({
+          name: hosts[k].name, hostname: hosts[k].hostname,
+          port: hosts[k].port, host_key: hosts[k].host_keys || [],
+          username: hosts[k].username || '',
+          default_command: hosts[k].default_command || ''
+        });
+      }
+      $.ajax({
+        url: '/api/hosts', type: 'PUT', contentType: 'application/json',
+        headers: {'X-Xsrftoken': get_xsrf_token()},
+        data: JSON.stringify({hosts: payload})
+      }).done(function() {
+        window.localStorage.setItem('webssh_migrated_commands', '1');
+        refresh_host_list();
+      });
+    }).always(function() {
+      migrate_local_commands.running = false;
+    });
+    // Note: on GET failure, neither the migrated-flag nor a host PUT ever
+    // happens here -- .fail() is intentionally not handled, so nothing is
+    // written and the migration is simply retried on a future page load.
   }
 
 
@@ -994,19 +1141,19 @@ jQuery(function($){
           encoding = 'utf-8',
           decoder = window.TextDecoder ? new window.TextDecoder(encoding) : encoding,
           termOptions = {
-            cursorBlink: true,
+            cursorBlink: user_settings.cursor_blink !== false,
             theme: {
-              background: url_opts_data.bgcolor || 'black',
-              foreground: url_opts_data.fontcolor || 'white',
-              cursor: url_opts_data.cursor || url_opts_data.fontcolor || 'white'
+              background: url_opts_data.bgcolor || user_settings.background || 'black',
+              foreground: url_opts_data.fontcolor || user_settings.foreground || 'white',
+              cursor: url_opts_data.cursor || user_settings.cursor ||
+                      url_opts_data.fontcolor || user_settings.foreground || 'white'
             }
           };
 
-      if (url_opts_data.fontsize) {
-        var fontsize = window.parseInt(url_opts_data.fontsize);
-        if (fontsize && fontsize > 0) {
-          termOptions.fontSize = fontsize;
-        }
+      var fontsize = window.parseInt(
+        url_opts_data.fontsize || user_settings.font_size, 10);
+      if (fontsize && fontsize > 0) {
+        termOptions.fontSize = fontsize;
       }
 
       var term = new window.Terminal(termOptions);
@@ -1842,7 +1989,20 @@ jQuery(function($){
 
   if (url_opts_data.term) {
     term_type.val(url_opts_data.term);
+  } else if (user_settings.term) {
+    term_type.val(user_settings.term);
   }
+
+  if (user_settings.key_source === 'stored' && user_key_enabled) {
+    $('#key_source_stored').prop('checked', true).trigger('change');
+  }
+
+  // One-time upgrade of any locally-stored per-host default commands onto
+  // the user's server-side host records. Safe to call before or after
+  // restore_default_command below; it only ever reads localStorage and the
+  // freshly-fetched /api/hosts list, and never PUTs a list it did not
+  // itself successfully fetch.
+  migrate_local_commands();
 
   // Create the first tab
   tabManager.createTab();

--- a/webssh/static/js/main.js
+++ b/webssh/static/js/main.js
@@ -387,6 +387,19 @@ jQuery(function($){
     }
   };
 
+  // Guard against user-hosts.js failing to load (404, blocked, etc).
+  // Placed here rather than at the very top of the closure because
+  // log_status() depends on status/waiter/form_container/validated_form_data
+  // (declared above) and on tabManager (defined immediately above this
+  // line) all being initialized. Without this guard, a missing
+  // webssh_hosts silently parses fine and the first ReferenceError does
+  // not fire until deep inside the connect .done() callback, after the
+  // WebSocket has already been opened.
+  if (typeof webssh_hosts === 'undefined') {
+    log_status('Client script failed to load; reload the page.', false);
+    return;
+  }
+
 
   // ===================== Utility Functions =====================
 

--- a/webssh/static/js/main.js
+++ b/webssh/static/js/main.js
@@ -545,11 +545,11 @@ jQuery(function($){
     var found = [];
     for (var i = 0; i < window.localStorage.length; i++) {
       var key = window.localStorage.key(i);
-      if (key && key.indexOf('command:') === 0) {
-        var parts = key.split(':');
+      var parsed = webssh_hosts.parse_command_key(key);
+      if (parsed) {
         found.push({
-          hostname: parts[1],
-          port: window.parseInt(parts[2], 10) || 22,
+          hostname: parsed.hostname,
+          port: parsed.port,
           command: window.localStorage.getItem(key)
         });
       }
@@ -560,32 +560,12 @@ jQuery(function($){
       return;
     }
     $.get('/api/hosts').done(function(data) {
-      var hosts = data.user_hosts || [];
-      var index = {};
-      for (var i = 0; i < hosts.length; i++) {
-        index[hosts[i].hostname + ':' + hosts[i].port] = hosts[i];
-      }
-      var changed = false;
-      for (var j = 0; j < found.length; j++) {
-        var match = index[found[j].hostname + ':' + found[j].port];
-        if (match && !match.default_command) {
-          match.default_command = found[j].command;
-          changed = true;
-        }
-      }
-      if (!changed) {
+      var merged = webssh_hosts.merge_migrated_commands(data.user_hosts || [], found);
+      if (!merged.changed) {
         window.localStorage.setItem('webssh_migrated_commands', '1');
         return;
       }
-      var payload = [];
-      for (var k = 0; k < hosts.length; k++) {
-        payload.push({
-          name: hosts[k].name, hostname: hosts[k].hostname,
-          port: hosts[k].port, host_key: hosts[k].host_keys || [],
-          username: hosts[k].username || '',
-          default_command: hosts[k].default_command || ''
-        });
-      }
+      var payload = merged.payload;
       $.ajax({
         url: '/api/hosts', type: 'PUT', contentType: 'application/json',
         headers: {'X-Xsrftoken': get_xsrf_token()},

--- a/webssh/static/js/main.js
+++ b/webssh/static/js/main.js
@@ -195,9 +195,7 @@ jQuery(function($){
       }
 
       // Rebind wssh proxy methods to this tab
-      if (tab.kind !== 'settings') {
-        this.bindWssh(tab);
-      }
+      this.bindWssh(tab);
     },
 
     closeTab: function(tabId) {
@@ -676,9 +674,9 @@ jQuery(function($){
       waiter.hide();
     }
 
-    // Only show form if the active tab is disconnected
+    // Only show form if the active tab is disconnected (and not the settings tab)
     var activeTab = tabManager.getActiveTab();
-    if (activeTab && activeTab.state !== CONNECTED) {
+    if (activeTab && activeTab.state !== CONNECTED && activeTab.kind !== 'settings') {
       if (form_container.css('display') === 'none') {
         form_container.show();
       }
@@ -711,7 +709,10 @@ jQuery(function($){
 
   function collect_host_rows(pane) {
     var hosts = [];
+    var error = null;
+    pane.find('#user-host-rows .host-port').removeClass('input-error');
     pane.find('#user-host-rows tr.user-host').each(function() {
+      if (error) return;
       var row = $(this);
       var hostname = row.find('.host-hostname').val().trim();
       if (!hostname) return;
@@ -721,17 +722,29 @@ jQuery(function($){
         var k = keys[i].trim();
         if (k) cleaned.push(k);
       }
-      var port = window.parseInt(row.find('.host-port').val(), 10);
-      hosts.push({
-        name: row.find('.host-name').val().trim() || hostname,
+      var name = row.find('.host-name').val().trim() || hostname;
+      var host = {
+        name: name,
         hostname: hostname,
-        port: port > 0 ? port : 22,
         host_key: cleaned,
         username: row.find('.host-username').val().trim(),
         default_command: row.find('.host-command').val().trim()
-      });
+      };
+      // Leave port unset when blank so the server applies its documented
+      // default; never rewrite a value the user actually typed.
+      var port_text = row.find('.host-port').val().trim();
+      if (port_text) {
+        var port = window.parseInt(port_text, 10);
+        if (!(port > 0 && port <= 65535)) {
+          row.find('.host-port').addClass('input-error');
+          error = 'Invalid port "' + port_text + '" for host "' + name + '" (must be 1-65535).';
+          return;
+        }
+        host.port = port;
+      }
+      hosts.push(host);
     });
-    return hosts;
+    return {hosts: hosts, error: error};
   }
 
 
@@ -782,22 +795,45 @@ jQuery(function($){
       pane.find('#set-key-source').val(user_settings.key_source);
     }
 
+    // The host list PUT honors an empty "hosts" array as "clear my list".
+    // Never let a save proceed from a list this pane failed to load, so
+    // keep Save disabled until the GET resolves (and leave it disabled,
+    // with an explicit error, if it fails).
+    pane.find('#settings-save').prop('disabled', true);
     $.get('/api/hosts').done(function(data) {
       var hosts = data.user_hosts || [];
       for (var i = 0; i < hosts.length; i++) {
         add_host_row(pane, hosts[i]);
       }
+      pane.find('#settings-save').prop('disabled', false);
+    }).fail(function() {
+      settings_status(
+        pane,
+        'Failed to load your existing hosts. Save is disabled to avoid ' +
+        'overwriting them; reload the tab and try again.',
+        true
+      );
     });
 
     pane.find('#settings-save').on('click', function() {
+      var collected = collect_host_rows(pane);
+      if (collected.error) {
+        settings_status(pane, collected.error, true);
+        return;
+      }
       settings_status(pane, 'Saving...');
-      var hosts = collect_host_rows(pane);
+      var hosts = collected.hosts;
       var settings = collect_settings(pane);
       $.ajax({
         url: '/api/hosts', type: 'PUT', contentType: 'application/json',
         headers: {'X-Xsrftoken': get_xsrf_token()},
         data: JSON.stringify({hosts: hosts})
       }).done(function() {
+        // Hosts are now persisted regardless of what happens to settings
+        // below, so refresh the dropdown now rather than only on full
+        // success -- otherwise a settings failure leaves the dropdown
+        // looking stale even though the hosts did save.
+        refresh_host_list();
         return $.ajax({
           url: '/api/settings', type: 'PUT', contentType: 'application/json',
           headers: {'X-Xsrftoken': get_xsrf_token()},
@@ -805,12 +841,15 @@ jQuery(function($){
         }).done(function(data) {
           user_settings = data.settings || {};
           settings_status(pane, 'Saved');
-          refresh_host_list();
         }).fail(function(xhr) {
-          settings_status(pane, save_error_text(xhr), true);
+          settings_status(
+            pane,
+            'Hosts saved, but settings failed to save: ' + save_error_text(xhr),
+            true
+          );
         });
       }).fail(function(xhr) {
-        settings_status(pane, save_error_text(xhr), true);
+        settings_status(pane, 'Hosts failed to save: ' + save_error_text(xhr), true);
       });
     });
   }
@@ -818,6 +857,9 @@ jQuery(function($){
 
   function save_error_text(xhr) {
     if (xhr && xhr.status === 400) {
+      if (xhr.responseJSON && xhr.responseJSON.error) {
+        return xhr.responseJSON.error;
+      }
       return 'Rejected: check hostnames, ports, and host keys.';
     }
     return 'Save failed.';
@@ -1398,6 +1440,12 @@ jQuery(function($){
     var result, opts;
     var tab = tabManager.getActiveTab();
 
+    // A settings tab is never a valid connect target; open a new terminal
+    // tab and connect there instead.
+    if (tab && tab.kind === 'settings') {
+      tab = tabManager.createTab('terminal');
+    }
+
     if (!tab || tab.state !== DISCONNECTED) {
       if (tab) {
         console.log(messages[tab.state]);
@@ -1508,7 +1556,10 @@ jQuery(function($){
     var host_username = option.attr('data-username');
     var host_command = option.attr('data-command');
     if (host_username) $('#username').val(host_username);
-    if (host_command !== undefined) $('#default-command').val(host_command);
+    // An empty default_command means "no host-specific override" -- leave
+    // whatever restore_default_command already populated from localStorage
+    // alone rather than blanking it.
+    if (host_command) $('#default-command').val(host_command);
   });
 
   // Restore default command when port changes
@@ -1597,9 +1648,11 @@ jQuery(function($){
       args = [args];
     }
 
-    // Create a new tab for cross-origin connections if current tab is connected
+    // Create a new tab for cross-origin connections if the current tab is
+    // already connected, or if it is the settings tab (never a valid
+    // connect target).
     var activeTab = tabManager.getActiveTab();
-    if (activeTab && activeTab.state === CONNECTED) {
+    if (activeTab && (activeTab.state === CONNECTED || activeTab.kind === 'settings')) {
       tabManager.createTab();
     }
 

--- a/webssh/static/js/main.js
+++ b/webssh/static/js/main.js
@@ -1006,13 +1006,8 @@ jQuery(function($){
 
 
   function save_error_text(xhr) {
-    if (xhr && xhr.status === 400) {
-      if (xhr.responseJSON && xhr.responseJSON.error) {
-        return xhr.responseJSON.error;
-      }
-      return 'Rejected: check hostnames, ports, and host keys.';
-    }
-    return 'Save failed.';
+    return webssh_hosts.save_error_text(
+      xhr ? xhr.status : 0, xhr ? xhr.responseJSON : null);
   }
 
 
@@ -1143,21 +1138,8 @@ jQuery(function($){
           sock = new window.WebSocket(url),
           encoding = 'utf-8',
           decoder = window.TextDecoder ? new window.TextDecoder(encoding) : encoding,
-          termOptions = {
-            cursorBlink: user_settings.cursor_blink !== false,
-            theme: {
-              background: url_opts_data.bgcolor || user_settings.background || 'black',
-              foreground: url_opts_data.fontcolor || user_settings.foreground || 'white',
-              cursor: url_opts_data.cursor || user_settings.cursor ||
-                      url_opts_data.fontcolor || user_settings.foreground || 'white'
-            }
-          };
-
-      var fontsize = window.parseInt(
-        url_opts_data.fontsize || user_settings.font_size, 10);
-      if (fontsize && fontsize > 0) {
-        termOptions.fontSize = fontsize;
-      }
+          termOptions = webssh_hosts.resolve_terminal_options(
+            url_opts_data, user_settings);
 
       var term = new window.Terminal(termOptions);
       var fitAddon = new window.FitAddon.FitAddon();

--- a/webssh/static/js/main.js
+++ b/webssh/static/js/main.js
@@ -902,14 +902,14 @@ jQuery(function($){
       // Leave port unset when blank so the server applies its documented
       // default; never rewrite a value the user actually typed.
       var port_text = row.find('.host-port').val().trim();
-      if (port_text) {
-        var port = window.parseInt(port_text, 10);
-        if (!(port > 0 && port <= 65535)) {
-          row.find('.host-port').addClass('input-error');
-          error = 'Invalid port "' + port_text + '" for host "' + name + '" (must be 1-65535).';
-          return;
-        }
-        host.port = port;
+      var port_result = webssh_hosts.validate_port(port_text);
+      if (port_result.invalid) {
+        row.find('.host-port').addClass('input-error');
+        error = 'Invalid port "' + port_text + '" for host "' + name + '" (must be 1-65535).';
+        return;
+      }
+      if (port_result.port) {
+        host.port = port_result.port;
       }
       hosts.push(host);
     });

--- a/webssh/static/js/main.js
+++ b/webssh/static/js/main.js
@@ -419,13 +419,6 @@ jQuery(function($){
   };
 
 
-  var ROAMING_FIELDS = {
-    hostname: 'last_hostname',
-    username: 'last_username',
-    port: 'last_port'
-  };
-
-
   function store_items(names, data) {
     var i, name, value;
 
@@ -434,11 +427,9 @@ jQuery(function($){
       value = data.get(name);
       if (value) {
         window.localStorage.setItem(name, value);
-        if (ROAMING_FIELDS[name]) {
-          var stored = (name === 'port') ? window.parseInt(value, 10) : value;
-          if (name !== 'port' || stored > 0) {
-            user_settings[ROAMING_FIELDS[name]] = stored;
-          }
+        var roamed = webssh_hosts.roaming_update(name, value);
+        if (roamed) {
+          user_settings[roamed.key] = roamed.value;
         }
       }
     }
@@ -525,8 +516,8 @@ jQuery(function($){
         continue;
       }
       value = null;
-      if (user_hosts_enabled && ROAMING_FIELDS[name]) {
-        var roamed = user_settings[ROAMING_FIELDS[name]];
+      if (user_hosts_enabled && webssh_hosts.ROAMING_FIELDS[name]) {
+        var roamed = user_settings[webssh_hosts.ROAMING_FIELDS[name]];
         if (roamed !== undefined && roamed !== null && roamed !== '') {
           value = String(roamed);
         }
@@ -902,30 +893,16 @@ jQuery(function($){
 
 
   function collect_settings(pane) {
-    var settings = {};
-    var size = window.parseInt(pane.find('#set-font-size').val(), 10);
-    if (size > 0) settings.font_size = size;
-    var pairs = {
-      background: '#set-background', foreground: '#set-foreground',
-      cursor: '#set-cursor', encoding: '#set-encoding', term: '#set-term'
-    };
-    for (var key in pairs) {
-      var value = pane.find(pairs[key]).val().trim();
-      if (value) settings[key] = value;
-    }
-    settings.cursor_blink = pane.find('#set-cursor-blink').is(':checked');
-    settings.key_source = pane.find('#set-key-source').val();
-    // The settings PUT replaces the whole stored blob, and this pane only
-    // knows about appearance keys. Carry over the roamed last-used values
-    // (and only those known keys, to keep the secrets invariant structural)
-    // so a Save here doesn't wipe them out for the user on another machine.
-    for (var roam_name in ROAMING_FIELDS) {
-      var roam_key = ROAMING_FIELDS[roam_name];
-      if (user_settings[roam_key] !== undefined) {
-        settings[roam_key] = user_settings[roam_key];
-      }
-    }
-    return settings;
+    return webssh_hosts.merge_settings(user_settings, {
+      font_size_text: pane.find('#set-font-size').val(),
+      background: pane.find('#set-background').val(),
+      foreground: pane.find('#set-foreground').val(),
+      cursor: pane.find('#set-cursor').val(),
+      encoding: pane.find('#set-encoding').val(),
+      term: pane.find('#set-term').val(),
+      cursor_blink: pane.find('#set-cursor-blink').is(':checked'),
+      key_source: pane.find('#set-key-source').val()
+    });
   }
 
 

--- a/webssh/static/js/main.js
+++ b/webssh/static/js/main.js
@@ -877,43 +877,27 @@ jQuery(function($){
 
 
   function collect_host_rows(pane) {
-    var hosts = [];
-    var error = null;
+    var rows = [];
+    var row_els = [];
     pane.find('#user-host-rows .host-port').removeClass('input-error');
     pane.find('#user-host-rows tr.user-host').each(function() {
-      if (error) return;
       var row = $(this);
-      var hostname = row.find('.host-hostname').val().trim();
-      if (!hostname) return;
-      var keys = row.find('.host-keys').val().split('\n');
-      var cleaned = [];
-      for (var i = 0; i < keys.length; i++) {
-        var k = keys[i].trim();
-        if (k) cleaned.push(k);
-      }
-      var name = row.find('.host-name').val().trim() || hostname;
-      var host = {
-        name: name,
-        hostname: hostname,
-        host_key: cleaned,
-        username: row.find('.host-username').val().trim(),
-        default_command: row.find('.host-command').val().trim()
-      };
-      // Leave port unset when blank so the server applies its documented
-      // default; never rewrite a value the user actually typed.
-      var port_text = row.find('.host-port').val().trim();
-      var port_result = webssh_hosts.validate_port(port_text);
-      if (port_result.invalid) {
-        row.find('.host-port').addClass('input-error');
-        error = 'Invalid port "' + port_text + '" for host "' + name + '" (must be 1-65535).';
-        return;
-      }
-      if (port_result.port) {
-        host.port = port_result.port;
-      }
-      hosts.push(host);
+      row_els.push(row);
+      rows.push({
+        name: row.find('.host-name').val(),
+        hostname: row.find('.host-hostname').val(),
+        port_text: row.find('.host-port').val(),
+        keys_text: row.find('.host-keys').val(),
+        username: row.find('.host-username').val(),
+        default_command: row.find('.host-command').val()
+      });
     });
-    return {hosts: hosts, error: error};
+
+    var built = webssh_hosts.build_host_payload(rows);
+    if (built.error && built.error_index >= 0) {
+      row_els[built.error_index].find('.host-port').addClass('input-error');
+    }
+    return {hosts: built.hosts, error: built.error};
   }
 
 

--- a/webssh/static/js/main.js
+++ b/webssh/static/js/main.js
@@ -391,22 +391,7 @@ jQuery(function($){
   // ===================== Utility Functions =====================
 
   var prefs = {
-    pending: null,
     timer: null,
-
-    get: function(name) {
-      if (user_hosts_enabled && user_settings[name] !== undefined) {
-        return user_settings[name];
-      }
-      return window.localStorage.getItem(name);
-    },
-
-    set: function(name, value) {
-      window.localStorage.setItem(name, value);
-      if (!user_hosts_enabled) return;
-      user_settings[name] = value;
-      this.schedule();
-    },
 
     schedule: function() {
       var self = this;
@@ -493,8 +478,14 @@ jQuery(function($){
     if (!hostname) return;
     var option = find_user_host(hostname, port);
     if (option) {
-      $('#default-command').val(option.attr('data-command') || '');
-      return;
+      var host_command = option.attr('data-command');
+      if (host_command) {
+        $('#default-command').val(host_command);
+        return;
+      }
+      // An empty default_command means "no host-specific override" -- fall
+      // through to the localStorage value below rather than blanking
+      // whatever the user has set locally for this host.
     }
     var key = get_host_key({hostname: hostname, port: port});
     if (!key) return;
@@ -909,6 +900,16 @@ jQuery(function($){
     }
     settings.cursor_blink = pane.find('#set-cursor-blink').is(':checked');
     settings.key_source = pane.find('#set-key-source').val();
+    // The settings PUT replaces the whole stored blob, and this pane only
+    // knows about appearance keys. Carry over the roamed last-used values
+    // (and only those known keys, to keep the secrets invariant structural)
+    // so a Save here doesn't wipe them out for the user on another machine.
+    for (var roam_name in ROAMING_FIELDS) {
+      var roam_key = ROAMING_FIELDS[roam_name];
+      if (user_settings[roam_key] !== undefined) {
+        settings[roam_key] = user_settings[roam_key];
+      }
+    }
     return settings;
   }
 
@@ -967,6 +968,16 @@ jQuery(function($){
       if (collected.error) {
         settings_status(pane, collected.error, true);
         return;
+      }
+      // Cancel any pending debounced flush from prefs.schedule() (armed by
+      // a recent connect via store_items). That flush closes over the
+      // outer user_settings binding and would otherwise race this save's
+      // own PUT: if it fires while this save is still in flight, it can
+      // land at the server with the pre-save object and silently revert
+      // whatever this pane just saved.
+      if (prefs.timer) {
+        window.clearTimeout(prefs.timer);
+        prefs.timer = null;
       }
       settings_status(pane, 'Saving...');
       var hosts = collected.hosts;

--- a/webssh/static/js/main.js
+++ b/webssh/static/js/main.js
@@ -71,7 +71,8 @@ jQuery(function($){
     activeTabId: null,
     tabCounter: 0,
 
-    createTab: function() {
+    createTab: function(kind) {
+      kind = kind || 'terminal';
       var tabId = ++this.tabCounter;
       var container = document.createElement('div');
       container.className = 'terminal-pane';
@@ -90,7 +91,7 @@ jQuery(function($){
 
       var label = document.createElement('span');
       label.className = 'tab-label';
-      label.textContent = 'New Connection';
+      label.textContent = (kind === 'settings') ? 'Settings' : 'New Connection';
 
       var closeBtn = document.createElement('button');
       closeBtn.className = 'tab-close';
@@ -124,7 +125,8 @@ jQuery(function($){
 
       var tab = {
         id: tabId,
-        label: 'New Connection',
+        kind: kind,
+        label: (kind === 'settings') ? 'Settings' : 'New Connection',
         state: DISCONNECTED,
         term: null,
         fitAddon: null,
@@ -164,7 +166,9 @@ jQuery(function($){
       // Dismiss any lingering status from other tabs
       dismiss_status();
 
-      if (tab.state === CONNECTED && tab.term) {
+      if (tab.kind === 'settings') {
+        form_container.hide();
+      } else if (tab.state === CONNECTED && tab.term) {
         form_container.hide();
         // Fit after a brief delay so layout settles, then focus
         setTimeout(function() {
@@ -182,14 +186,18 @@ jQuery(function($){
 
 
       // Update page title
-      if (tab.state === CONNECTED && tab.title) {
+      if (tab.kind === 'settings') {
+        title_element.text = 'Settings';
+      } else if (tab.state === CONNECTED && tab.title) {
         title_element.text = tab.title;
       } else {
         title_element.text = default_title;
       }
 
       // Rebind wssh proxy methods to this tab
-      this.bindWssh(tab);
+      if (tab.kind !== 'settings') {
+        this.bindWssh(tab);
+      }
     },
 
     closeTab: function(tabId) {
@@ -237,13 +245,35 @@ jQuery(function($){
           this.activateTab(ids[idx]);
         } else {
           // No tabs left, create new one
-          this.createTab();
+          this.createTab('terminal');
         }
       }
     },
 
     getActiveTab: function() {
       return this.tabs[this.activeTabId] || null;
+    },
+
+    openSettings: function() {
+      var ids = this.getTabIds();
+      for (var i = 0; i < ids.length; i++) {
+        if (this.tabs[ids[i]].kind === 'settings') {
+          this.activateTab(ids[i]);
+          return;
+        }
+      }
+      var tab = this.createTab('settings');
+      var pane = $(tab.containerEl);
+      pane.html('<div class="settings-loading">Loading settings...</div>');
+      $.get('/settings-pane')
+        .done(function(html) {
+          pane.html(html);
+          init_settings_pane(pane);
+        })
+        .fail(function() {
+          pane.html('<div class="settings-loading">Failed to load settings.</div>');
+        });
+      return tab;
     },
 
     updateTabLabel: function(tabId, label) {
@@ -653,6 +683,178 @@ jQuery(function($){
         form_container.show();
       }
     }
+  }
+
+
+  // ===================== Settings Pane =====================
+
+  function settings_status(pane, message, is_error) {
+    var el = pane.find('#settings-status');
+    el.text(message || '');
+    el.toggleClass('error', !!is_error);
+  }
+
+
+  function add_host_row(pane, host) {
+    host = host || {};
+    var tpl = pane.find('#host-row-template')[0];
+    var row = $(document.importNode(tpl.content, true));
+    row.find('.host-name').val(host.name || '');
+    row.find('.host-hostname').val(host.hostname || '');
+    row.find('.host-port').val(host.port || '');
+    row.find('.host-username').val(host.username || '');
+    row.find('.host-command').val(host.default_command || '');
+    row.find('.host-keys').val((host.host_keys || []).join('\n'));
+    pane.find('#user-host-rows').append(row);
+  }
+
+
+  function collect_host_rows(pane) {
+    var hosts = [];
+    pane.find('#user-host-rows tr.user-host').each(function() {
+      var row = $(this);
+      var hostname = row.find('.host-hostname').val().trim();
+      if (!hostname) return;
+      var keys = row.find('.host-keys').val().split('\n');
+      var cleaned = [];
+      for (var i = 0; i < keys.length; i++) {
+        var k = keys[i].trim();
+        if (k) cleaned.push(k);
+      }
+      var port = window.parseInt(row.find('.host-port').val(), 10);
+      hosts.push({
+        name: row.find('.host-name').val().trim() || hostname,
+        hostname: hostname,
+        port: port > 0 ? port : 22,
+        host_key: cleaned,
+        username: row.find('.host-username').val().trim(),
+        default_command: row.find('.host-command').val().trim()
+      });
+    });
+    return hosts;
+  }
+
+
+  function collect_settings(pane) {
+    var settings = {};
+    var size = window.parseInt(pane.find('#set-font-size').val(), 10);
+    if (size > 0) settings.font_size = size;
+    var pairs = {
+      background: '#set-background', foreground: '#set-foreground',
+      cursor: '#set-cursor', encoding: '#set-encoding', term: '#set-term'
+    };
+    for (var key in pairs) {
+      var value = pane.find(pairs[key]).val().trim();
+      if (value) settings[key] = value;
+    }
+    settings.cursor_blink = pane.find('#set-cursor-blink').is(':checked');
+    settings.key_source = pane.find('#set-key-source').val();
+    return settings;
+  }
+
+
+  function init_settings_pane(pane) {
+    pane.find('.settings-tab').on('click', function() {
+      var section = $(this).data('section');
+      pane.find('.settings-tab').removeClass('active');
+      $(this).addClass('active');
+      pane.find('.settings-section').removeClass('active');
+      pane.find('#settings-' + section).addClass('active');
+    });
+
+    pane.find('#add-host-btn').on('click', function() {
+      add_host_row(pane, {});
+    });
+
+    pane.on('click', '.host-delete', function() {
+      $(this).closest('tr').remove();
+    });
+
+    pane.find('#set-font-size').val(user_settings.font_size || '');
+    pane.find('#set-background').val(user_settings.background || '');
+    pane.find('#set-foreground').val(user_settings.foreground || '');
+    pane.find('#set-cursor').val(user_settings.cursor || '');
+    pane.find('#set-encoding').val(user_settings.encoding || '');
+    pane.find('#set-term').val(user_settings.term || '');
+    pane.find('#set-cursor-blink').prop('checked',
+                                        user_settings.cursor_blink !== false);
+    if (user_settings.key_source) {
+      pane.find('#set-key-source').val(user_settings.key_source);
+    }
+
+    $.get('/api/hosts').done(function(data) {
+      var hosts = data.user_hosts || [];
+      for (var i = 0; i < hosts.length; i++) {
+        add_host_row(pane, hosts[i]);
+      }
+    });
+
+    pane.find('#settings-save').on('click', function() {
+      settings_status(pane, 'Saving...');
+      var hosts = collect_host_rows(pane);
+      var settings = collect_settings(pane);
+      $.ajax({
+        url: '/api/hosts', type: 'PUT', contentType: 'application/json',
+        headers: {'X-Xsrftoken': get_xsrf_token()},
+        data: JSON.stringify({hosts: hosts})
+      }).done(function() {
+        return $.ajax({
+          url: '/api/settings', type: 'PUT', contentType: 'application/json',
+          headers: {'X-Xsrftoken': get_xsrf_token()},
+          data: JSON.stringify({settings: settings})
+        }).done(function(data) {
+          user_settings = data.settings || {};
+          settings_status(pane, 'Saved');
+          refresh_host_list();
+        }).fail(function(xhr) {
+          settings_status(pane, save_error_text(xhr), true);
+        });
+      }).fail(function(xhr) {
+        settings_status(pane, save_error_text(xhr), true);
+      });
+    });
+  }
+
+
+  function save_error_text(xhr) {
+    if (xhr && xhr.status === 400) {
+      return 'Rejected: check hostnames, ports, and host keys.';
+    }
+    return 'Save failed.';
+  }
+
+
+  function get_xsrf_token() {
+    var match = document.cookie.match(/\b_xsrf=([^;]+)/);
+    return match ? decodeURIComponent(match[1]) : '';
+  }
+
+
+  function refresh_host_list() {
+    if (!user_hosts_enabled) return;
+    $.get('/api/hosts').done(function(data) {
+      var select = $('#hostname');
+      if (!select.is('select')) return;
+      var current = select.val();
+      select.empty();
+      var groups = [data.admin_hosts || [], data.user_hosts || []];
+      for (var g = 0; g < groups.length; g++) {
+        for (var i = 0; i < groups[g].length; i++) {
+          var host = groups[g][i];
+          var option = $('<option>')
+            .attr('value', host.hostname)
+            .attr('data-port', host.port)
+            .text(host.name);
+          if (g === 1) {
+            option.attr('data-username', host.username || '');
+            option.attr('data-command', host.default_command || '');
+          }
+          select.append(option);
+        }
+      }
+      if (current) select.val(current);
+      select.trigger('change');
+    });
   }
 
 
@@ -1301,6 +1503,12 @@ jQuery(function($){
     }
     restore_default_command($(this).val(), port || $('#port').val());
     update_advanced_summary();
+
+    var option = $('#hostname option:selected');
+    var host_username = option.attr('data-username');
+    var host_command = option.attr('data-command');
+    if (host_username) $('#username').val(host_username);
+    if (host_command !== undefined) $('#default-command').val(host_command);
   });
 
   // Restore default command when port changes
@@ -1430,6 +1638,10 @@ jQuery(function($){
 
   $('#new-tab-btn').on('click', function() {
     tabManager.createTab();
+  });
+
+  $('#settings-btn').on('click', function() {
+    tabManager.openSettings();
   });
 
 

--- a/webssh/static/js/user-hosts.js
+++ b/webssh/static/js/user-hosts.js
@@ -25,8 +25,62 @@ var webssh_hosts = (function () {
     return {port: port};
   }
 
+  function split_keys(text) {
+    var raw = (text === undefined || text === null) ? '' : String(text);
+    var parts = raw.split('\n');
+    var cleaned = [];
+    for (var i = 0; i < parts.length; i++) {
+      var k = parts[i].trim();
+      if (k) {
+        cleaned.push(k);
+      }
+    }
+    return cleaned;
+  }
+
+  function trimmed(value) {
+    return (value === undefined || value === null) ? '' : String(value).trim();
+  }
+
+  // rows: [{name, hostname, port_text, keys_text, username, default_command}]
+  // Rows with a blank hostname are skipped, matching the pane's behaviour of
+  // ignoring a half-filled row rather than submitting it.
+  function build_host_payload(rows) {
+    var result = [];
+    for (var i = 0; i < rows.length; i++) {
+      var r = rows[i];
+      var hostname = trimmed(r.hostname);
+      if (!hostname) {
+        continue;
+      }
+      var name = trimmed(r.name) || hostname;
+      var host = {
+        name: name,
+        hostname: hostname,
+        host_key: split_keys(r.keys_text),
+        username: trimmed(r.username),
+        default_command: trimmed(r.default_command)
+      };
+      var port_result = validate_port(r.port_text);
+      if (port_result.invalid) {
+        return {
+          hosts: [],
+          error: 'Invalid port "' + trimmed(r.port_text) +
+                 '" for host "' + name + '" (must be 1-65535).',
+          error_index: i
+        };
+      }
+      if (port_result.port) {
+        host.port = port_result.port;
+      }
+      result.push(host);
+    }
+    return {hosts: result, error: null, error_index: -1};
+  }
+
   return {
-    validate_port: validate_port
+    validate_port: validate_port,
+    build_host_payload: build_host_payload
   };
 }());
 

--- a/webssh/static/js/user-hosts.js
+++ b/webssh/static/js/user-hosts.js
@@ -136,12 +136,44 @@ var webssh_hosts = (function () {
     return {key: roam_key, value: value};
   }
 
+  // Precedence: URL parameter, then stored preference, then built-in default.
+  function resolve_terminal_options(url_opts, stored) {
+    var options = {
+      cursorBlink: stored.cursor_blink !== false,
+      theme: {
+        background: url_opts.bgcolor || stored.background || 'black',
+        foreground: url_opts.fontcolor || stored.foreground || 'white',
+        cursor: url_opts.cursor || stored.cursor ||
+                url_opts.fontcolor || stored.foreground || 'white'
+      }
+    };
+    var fontsize = parseInt(url_opts.fontsize || stored.font_size, 10);
+    if (fontsize && fontsize > 0) {
+      options.fontSize = fontsize;
+    }
+    return options;
+  }
+
+  // A 400 describes the user's own input and is safe to show. Anything else
+  // may describe server state, so it gets a fixed generic message.
+  function save_error_text(status, body) {
+    if (status === 400) {
+      if (body && body.error) {
+        return body.error;
+      }
+      return 'Rejected: check hostnames, ports, and host keys.';
+    }
+    return 'Save failed.';
+  }
+
   return {
     validate_port: validate_port,
     build_host_payload: build_host_payload,
     ROAMING_FIELDS: ROAMING_FIELDS,
     merge_settings: merge_settings,
-    roaming_update: roaming_update
+    roaming_update: roaming_update,
+    resolve_terminal_options: resolve_terminal_options,
+    save_error_text: save_error_text
   };
 }());
 

--- a/webssh/static/js/user-hosts.js
+++ b/webssh/static/js/user-hosts.js
@@ -42,7 +42,20 @@ var webssh_hosts = (function () {
     return (value === undefined || value === null) ? '' : String(value).trim();
   }
 
+  // The row keys build_host_payload reads from each element of `rows`, in
+  // the same order they are read below. This list is the ONLY thing tying
+  // main.js's DOM-reading collect_host_rows to what this module consumes --
+  // main.js has no other reference to these names, so a typo on either side
+  // (e.g. keys_text -> key_text) compiles fine and silently breaks at
+  // runtime. Keep this array and the r.<key> reads immediately below it in
+  // sync. tests/js/user-hosts.test.js has a seam test that reads main.js as
+  // text and asserts every one of these keys still appears there, which is
+  // the only way to catch a rename on the main.js side: a pure module has
+  // no way to observe its DOM-reading caller directly.
+  var HOST_ROW_KEYS = ['name', 'hostname', 'port_text', 'keys_text', 'username', 'default_command'];
+
   // rows: [{name, hostname, port_text, keys_text, username, default_command}]
+  // (see HOST_ROW_KEYS above)
   // Rows with a blank hostname are skipped, matching the pane's behaviour of
   // ignoring a half-filled row rather than submitting it.
   function build_host_payload(rows) {
@@ -216,6 +229,7 @@ var webssh_hosts = (function () {
   return {
     validate_port: validate_port,
     build_host_payload: build_host_payload,
+    HOST_ROW_KEYS: HOST_ROW_KEYS,
     ROAMING_FIELDS: ROAMING_FIELDS,
     merge_settings: merge_settings,
     roaming_update: roaming_update,

--- a/webssh/static/js/user-hosts.js
+++ b/webssh/static/js/user-hosts.js
@@ -1,0 +1,35 @@
+/*jslint browser:true */
+/*
+ * Pure decision logic for the user-managed hosts and settings feature.
+ *
+ * This module holds no DOM access and no jQuery dependency: main.js reads
+ * the settings pane into plain values and passes them here. That keeps this
+ * file unit-testable under `node --test` with no browser and no packages.
+ */
+
+var webssh_hosts = (function () {
+  'use strict';
+
+  // Returns exactly one of {omit: true}, {port: n}, or {invalid: true}.
+  // A blank port is omitted rather than defaulted here, so the server
+  // applies its own documented default; a typed value is never rewritten.
+  function validate_port(text) {
+    var trimmed = (text === undefined || text === null) ? '' : String(text).trim();
+    if (!trimmed) {
+      return {omit: true};
+    }
+    var port = parseInt(trimmed, 10);
+    if (!(port > 0 && port <= 65535)) {
+      return {invalid: true};
+    }
+    return {port: port};
+  }
+
+  return {
+    validate_port: validate_port
+  };
+}());
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = webssh_hosts;
+}

--- a/webssh/static/js/user-hosts.js
+++ b/webssh/static/js/user-hosts.js
@@ -63,8 +63,13 @@ var webssh_hosts = (function () {
       };
       var port_result = validate_port(r.port_text);
       if (port_result.invalid) {
+        // Preserve hosts collected before this row, matching the original
+        // inline behaviour. Returning [] here looks tidy but is a trap:
+        // PUT /api/hosts treats an explicit empty list as "clear my hosts",
+        // so a caller that reads .hosts without checking .error would wipe
+        // the user's saved hosts and pinned keys.
         return {
-          hosts: [],
+          hosts: result,
           error: 'Invalid port "' + trimmed(r.port_text) +
                  '" for host "' + name + '" (must be 1-65535).',
           error_index: i

--- a/webssh/static/js/user-hosts.js
+++ b/webssh/static/js/user-hosts.js
@@ -83,9 +83,65 @@ var webssh_hosts = (function () {
     return {hosts: result, error: null, error_index: -1};
   }
 
+  // Form field name -> stored settings key. These three are the ONLY fields
+  // that roam. Everything else in the form, including credential and totp,
+  // is deliberately absent so secrets cannot reach the server structurally.
+  var ROAMING_FIELDS = {
+    hostname: 'last_hostname',
+    username: 'last_username',
+    port: 'last_port'
+  };
+
+  var APPEARANCE_KEYS = ['background', 'foreground', 'cursor', 'encoding', 'term'];
+
+  function merge_settings(current, ui) {
+    var settings = {};
+    var size = parseInt(ui.font_size_text, 10);
+    if (size > 0) {
+      settings.font_size = size;
+    }
+    for (var i = 0; i < APPEARANCE_KEYS.length; i++) {
+      var key = APPEARANCE_KEYS[i];
+      var value = trimmed(ui[key]);
+      if (value) {
+        settings[key] = value;
+      }
+    }
+    settings.cursor_blink = ui.cursor_blink;
+    settings.key_source = ui.key_source;
+    // The settings PUT replaces the whole stored blob and this pane only
+    // knows appearance keys, so carry the roamed values forward. Only the
+    // known keys, to keep the secrets invariant structural.
+    for (var name in ROAMING_FIELDS) {
+      var roam_key = ROAMING_FIELDS[name];
+      if (current[roam_key] !== undefined) {
+        settings[roam_key] = current[roam_key];
+      }
+    }
+    return settings;
+  }
+
+  function roaming_update(name, value) {
+    var roam_key = ROAMING_FIELDS[name];
+    if (!roam_key) {
+      return null;
+    }
+    if (name === 'port') {
+      var port = parseInt(value, 10);
+      if (!(port > 0)) {
+        return null;
+      }
+      return {key: roam_key, value: port};
+    }
+    return {key: roam_key, value: value};
+  }
+
   return {
     validate_port: validate_port,
-    build_host_payload: build_host_payload
+    build_host_payload: build_host_payload,
+    ROAMING_FIELDS: ROAMING_FIELDS,
+    merge_settings: merge_settings,
+    roaming_update: roaming_update
   };
 }());
 

--- a/webssh/static/js/user-hosts.js
+++ b/webssh/static/js/user-hosts.js
@@ -166,6 +166,53 @@ var webssh_hosts = (function () {
     return 'Save failed.';
   }
 
+  // Legacy per-host default commands were stored under 'command:<host>:<port>'.
+  function parse_command_key(key) {
+    if (!key || String(key).indexOf('command:') !== 0) {
+      return null;
+    }
+    var parts = String(key).split(':');
+    return {
+      hostname: parts[1],
+      port: parseInt(parts[2], 10) || 22
+    };
+  }
+
+  // Returns the full replacement payload, since PUT /api/hosts replaces the
+  // whole list. Every stored field is carried through; only default_command
+  // is filled in, and only where the host has none.
+  function merge_migrated_commands(stored_hosts, found) {
+    var index = {};
+    var i;
+    for (i = 0; i < stored_hosts.length; i++) {
+      index[stored_hosts[i].hostname + ':' + stored_hosts[i].port] = stored_hosts[i];
+    }
+    var changed = false;
+    for (i = 0; i < found.length; i++) {
+      var match = index[found[i].hostname + ':' + found[i].port];
+      if (match && !match.default_command) {
+        match.default_command = found[i].command;
+        changed = true;
+      }
+    }
+    if (!changed) {
+      return {payload: [], changed: false};
+    }
+    var payload = [];
+    for (i = 0; i < stored_hosts.length; i++) {
+      var h = stored_hosts[i];
+      payload.push({
+        name: h.name,
+        hostname: h.hostname,
+        port: h.port,
+        host_key: h.host_keys || [],
+        username: h.username || '',
+        default_command: h.default_command || ''
+      });
+    }
+    return {payload: payload, changed: true};
+  }
+
   return {
     validate_port: validate_port,
     build_host_payload: build_host_payload,
@@ -173,7 +220,9 @@ var webssh_hosts = (function () {
     merge_settings: merge_settings,
     roaming_update: roaming_update,
     resolve_terminal_options: resolve_terminal_options,
-    save_error_text: save_error_text
+    save_error_text: save_error_text,
+    parse_command_key: parse_command_key,
+    merge_migrated_commands: merge_migrated_commands
   };
 }());
 

--- a/webssh/templates/index.html
+++ b/webssh/templates/index.html
@@ -188,6 +188,7 @@
       var user_hosts_enabled = {% if user_hosts_enabled %}true{% else %}false{% end %};
       var user_settings = {% raw json_encode(user_settings) %};
     </script>
+    <script src="static/js/user-hosts.js"></script>
     <script src="static/js/main.js"></script>
   </body>
 </html>

--- a/webssh/templates/index.html
+++ b/webssh/templates/index.html
@@ -57,7 +57,7 @@
                   <option value="{{ host['hostname'] }}" data-port="{{ host['port'] }}">{{ host['name'] }}</option>
                   {% end %}
                   {% for host in user_hosts %}
-                  <option value="{{ host['hostname'] }}" data-port="{{ host['port'] }}" data-username="{{ host['username'] }}" data-command="{{ host['default_command'] }}">{{ host['name'] }}</option>
+                  <option value="{{ host['hostname'] }}" data-port="{{ host['port'] }}" data-username="{{ host.get('username', '') }}" data-command="{{ host.get('default_command', '') }}">{{ host['name'] }}</option>
                   {% end %}
                 </select>
                 {% else %}

--- a/webssh/templates/index.html
+++ b/webssh/templates/index.html
@@ -26,7 +26,7 @@
     <div id="tab-bar">
       <div id="tab-list"></div>
       <button id="new-tab-btn" type="button" title="New connection" aria-label="Open new connection tab">+</button>
-      {% if user_hosts_enabled %}
+      {% if user_hosts_enabled and auth_username %}
       <button id="settings-btn" type="button" title="Settings" aria-label="Open settings">&#9881;</button>
       {% end %}
     </div>

--- a/webssh/templates/index.html
+++ b/webssh/templates/index.html
@@ -27,7 +27,7 @@
       <div id="tab-list"></div>
       <button id="new-tab-btn" type="button" title="New connection" aria-label="Open new connection tab">+</button>
       {% if user_hosts_enabled and auth_username %}
-      <button id="settings-btn" type="button" title="Settings" aria-label="Open settings">&#9881;</button>
+      <button id="settings-btn" type="button" title="Settings" aria-label="Open settings">&#9881;&#xFE0E;</button>
       {% end %}
     </div>
 

--- a/webssh/templates/index.html
+++ b/webssh/templates/index.html
@@ -26,6 +26,9 @@
     <div id="tab-bar">
       <div id="tab-list"></div>
       <button id="new-tab-btn" type="button" title="New connection" aria-label="Open new connection tab">+</button>
+      {% if user_hosts_enabled %}
+      <button id="settings-btn" type="button" title="Settings" aria-label="Open settings">&#9881;</button>
+      {% end %}
     </div>
 
     <div class="form-container">
@@ -48,10 +51,13 @@
             <div class="field-row single">
               <div class="field-group">
                 <span class="field-label">Hostname</span>
-                {% if allowed_hosts %}
+                {% if allowed_hosts or user_hosts %}
                 <select class="field-input" id="hostname" name="hostname" required>
                   {% for host in allowed_hosts %}
                   <option value="{{ host['hostname'] }}" data-port="{{ host['port'] }}">{{ host['name'] }}</option>
+                  {% end %}
+                  {% for host in user_hosts %}
+                  <option value="{{ host['hostname'] }}" data-port="{{ host['port'] }}" data-username="{{ host['username'] }}" data-command="{{ host['default_command'] }}">{{ host['name'] }}</option>
                   {% end %}
                 </select>
                 {% else %}
@@ -81,7 +87,7 @@
               <div class="field-row">
                 <div class="field-group">
                   <span class="field-label">Port</span>
-                  <input class="field-input" type="number" id="port" name="port" placeholder="22" value="" min=1 max=65535 {% if allowed_hosts %}readonly{% end %}>
+                  <input class="field-input" type="number" id="port" name="port" placeholder="22" value="" min=1 max=65535 {% if allowed_hosts or user_hosts %}readonly{% end %}>
                 </div>
                 <div class="field-group">
                   <span class="field-label">TOTP <span class="label-hint">(optional)</span></span>
@@ -176,9 +182,11 @@
     <script src="static/js/xterm-addon-clipboard.min.js"></script>
     <script src="static/js/xterm-addon-webgl.min.js"></script>
     <script>
-      var allowed_hosts_configured = {% if allowed_hosts %}true{% else %}false{% end %};
+      var allowed_hosts_configured = {% if allowed_hosts or user_hosts %}true{% else %}false{% end %};
       var user_key_enabled = {% if user_key_enabled %}true{% else %}false{% end %};
       var has_stored_key = {% if has_stored_key %}true{% else %}false{% end %};
+      var user_hosts_enabled = {% if user_hosts_enabled %}true{% else %}false{% end %};
+      var user_settings = {% raw json_encode(user_settings) %};
     </script>
     <script src="static/js/main.js"></script>
   </body>

--- a/webssh/templates/settings.html
+++ b/webssh/templates/settings.html
@@ -1,0 +1,105 @@
+<div class="settings-pane">
+  <div class="settings-header">
+    <span class="settings-title">Settings</span>
+    <span class="settings-user">{{ auth_username }}</span>
+  </div>
+
+  <div class="settings-tabs" role="tablist">
+    <button type="button" class="settings-tab active" data-section="hosts" role="tab">Hosts</button>
+    <button type="button" class="settings-tab" data-section="terminal" role="tab">Terminal</button>
+    <button type="button" class="settings-tab" data-section="connection" role="tab">Connection</button>
+  </div>
+
+  <div class="settings-body">
+    <section id="settings-hosts" class="settings-section active">
+      {% if admin_hosts %}
+      <div class="settings-subhead">Administrator hosts (read-only)</div>
+      <table class="settings-table">
+        <tbody>
+          {% for host in admin_hosts %}
+          <tr class="admin-host">
+            <td>{{ host['name'] }}</td>
+            <td>{{ host['hostname'] }}</td>
+            <td>{{ host['port'] }}</td>
+            <td><span class="host-badge">admin</span></td>
+          </tr>
+          {% end %}
+        </tbody>
+      </table>
+      {% end %}
+
+      <div class="settings-subhead">Your hosts</div>
+      <table class="settings-table">
+        <tbody id="user-host-rows"></tbody>
+      </table>
+      <button type="button" class="btn-generate" id="add-host-btn">+ Add host</button>
+    </section>
+
+    <section id="settings-terminal" class="settings-section">
+      <div class="field-row">
+        <div class="field-group">
+          <span class="field-label">Font Size</span>
+          <input class="field-input" type="number" id="set-font-size" min="6" max="40" placeholder="14">
+        </div>
+        <div class="field-group">
+          <span class="field-label">Background</span>
+          <input class="field-input" type="text" id="set-background" placeholder="black">
+        </div>
+      </div>
+      <div class="field-row">
+        <div class="field-group">
+          <span class="field-label">Foreground</span>
+          <input class="field-input" type="text" id="set-foreground" placeholder="white">
+        </div>
+        <div class="field-group">
+          <span class="field-label">Cursor</span>
+          <input class="field-input" type="text" id="set-cursor" placeholder="white">
+        </div>
+      </div>
+      <div class="field-row single">
+        <label class="settings-checkbox">
+          <input type="checkbox" id="set-cursor-blink"> Cursor blink
+        </label>
+      </div>
+    </section>
+
+    <section id="settings-connection" class="settings-section">
+      <div class="field-row">
+        <div class="field-group">
+          <span class="field-label">Encoding</span>
+          <input class="field-input" type="text" id="set-encoding" placeholder="utf-8">
+        </div>
+        <div class="field-group">
+          <span class="field-label">Terminal Type</span>
+          <input class="field-input" type="text" id="set-term" placeholder="xterm-256color">
+        </div>
+      </div>
+      <div class="field-row single">
+        <div class="field-group">
+          <span class="field-label">Preferred Key Source</span>
+          <select class="field-input" id="set-key-source">
+            <option value="upload">Upload Key</option>
+            <option value="stored">Stored Key</option>
+          </select>
+        </div>
+      </div>
+    </section>
+  </div>
+
+  <div class="settings-footer">
+    <span class="settings-status" id="settings-status"></span>
+    <button type="button" class="btn-connect btn-primary" id="settings-save">Save</button>
+  </div>
+</div>
+
+<template id="host-row-template">
+  <tr class="user-host">
+    <td><input class="field-input host-name" type="text" placeholder="Name"></td>
+    <td><input class="field-input host-hostname" type="text" placeholder="hostname" required></td>
+    <td><input class="field-input host-port" type="number" min="1" max="65535" placeholder="22"></td>
+    <td><input class="field-input host-username" type="text" placeholder="login user"></td>
+    <td><input class="field-input host-command" type="text" placeholder="default command"></td>
+    <td><textarea class="field-input host-keys" rows="2" placeholder="ssh-ed25519 AAAA... (one per line)"></textarea></td>
+    <td><button type="button" class="btn-reset btn-danger host-delete" title="Delete host">&times;</button></td>
+  </tr>
+</template>

--- a/webssh/user_data.py
+++ b/webssh/user_data.py
@@ -1,0 +1,203 @@
+import json
+import logging
+import os
+import re
+import tempfile
+
+from webssh.settings import parse_host_entry
+from webssh.user_keys import sanitize_username
+from webssh.utils import is_valid_encoding
+
+
+SCHEMA_VERSION = 1
+MAX_HOSTS = 200
+MAX_FIELD_LENGTH = 512
+
+HOSTS_FILENAME = 'hosts.json'
+SETTINGS_FILENAME = 'settings.json'
+
+COLOR_RE = re.compile(r'^(#[0-9a-fA-F]{3}|#[0-9a-fA-F]{6}|[a-zA-Z]{1,20})$')
+TERM_RE = re.compile(r'^[a-zA-Z0-9._-]{1,32}$')
+
+# Only these keys are ever persisted. Anything else — notably passwords,
+# TOTP codes, and passphrases — is dropped.
+COLOR_SETTINGS = ('background', 'foreground', 'cursor')
+STRING_SETTINGS = ('last_hostname', 'last_username')
+
+
+def get_user_data_dir(base_dir, username):
+    sanitize_username(username)
+    user_dir = os.path.join(base_dir, username)
+    real_base = os.path.realpath(base_dir)
+    real_user = os.path.realpath(user_dir)
+    if not real_user.startswith(real_base + os.sep):
+        raise ValueError('Invalid username.')
+    return real_user
+
+
+def _check_string(value, name, allow_empty=True):
+    if not isinstance(value, str):
+        raise ValueError('{} must be a string'.format(name))
+    if len(value) > MAX_FIELD_LENGTH:
+        raise ValueError('{} is too long'.format(name))
+    if not allow_empty and not value:
+        raise ValueError('{} must not be empty'.format(name))
+    return value
+
+
+def validate_hosts(hosts):
+    if not isinstance(hosts, list):
+        raise ValueError('hosts must be a list')
+    if len(hosts) > MAX_HOSTS:
+        raise ValueError('Too many hosts; the limit is {}'.format(MAX_HOSTS))
+
+    result = []
+    for entry in hosts:
+        host = parse_host_entry(entry)
+        host['username'] = _check_string(
+            entry.get('username', ''), 'username')
+        host['default_command'] = _check_string(
+            entry.get('default_command', ''), 'default_command')
+        result.append(host)
+    return result
+
+
+def validate_settings(settings):
+    if not isinstance(settings, dict):
+        raise ValueError('settings must be a mapping')
+
+    result = {}
+
+    if 'font_size' in settings:
+        value = settings['font_size']
+        if isinstance(value, bool) or not isinstance(value, int):
+            raise ValueError('font_size must be an integer')
+        if value < 6 or value > 40:
+            raise ValueError('font_size must be between 6 and 40')
+        result['font_size'] = value
+
+    for name in COLOR_SETTINGS:
+        if name in settings:
+            value = settings[name]
+            if not isinstance(value, str) or not COLOR_RE.match(value):
+                raise ValueError('Invalid color for {}'.format(name))
+            result[name] = value
+
+    if 'cursor_blink' in settings:
+        value = settings['cursor_blink']
+        if not isinstance(value, bool):
+            raise ValueError('cursor_blink must be a boolean')
+        result['cursor_blink'] = value
+
+    if 'encoding' in settings:
+        value = settings['encoding']
+        if not isinstance(value, str) or not is_valid_encoding(value):
+            raise ValueError('Invalid encoding {!r}'.format(value))
+        result['encoding'] = value
+
+    if 'term' in settings:
+        value = settings['term']
+        if not isinstance(value, str) or not TERM_RE.match(value):
+            raise ValueError('Invalid term {!r}'.format(value))
+        result['term'] = value
+
+    if 'key_source' in settings:
+        value = settings['key_source']
+        if value not in ('stored', 'upload'):
+            raise ValueError('key_source must be "stored" or "upload"')
+        result['key_source'] = value
+
+    for name in STRING_SETTINGS:
+        if name in settings:
+            result[name] = _check_string(settings[name], name)
+
+    if 'last_port' in settings:
+        value = settings['last_port']
+        if isinstance(value, bool) or not isinstance(value, int):
+            raise ValueError('last_port must be an integer')
+        if value < 1 or value > 65535:
+            raise ValueError('last_port must be between 1 and 65535')
+        result['last_port'] = value
+
+    return result
+
+
+def _read_json(base_dir, username, filename, payload_key, empty):
+    user_dir = get_user_data_dir(base_dir, username)
+    path = os.path.join(user_dir, filename)
+    if not os.path.isfile(path):
+        return empty
+    try:
+        with open(path, 'r') as f:
+            data = json.load(f)
+    except (ValueError, OSError) as exc:
+        logging.warning(
+            'Ignoring unreadable {} for user {!r}: {}'.format(
+                filename, username, exc)
+        )
+        return empty
+    if not isinstance(data, dict):
+        logging.warning(
+            'Ignoring malformed {} for user {!r}'.format(filename, username))
+        return empty
+    payload = data.get(payload_key, empty)
+    if not isinstance(payload, type(empty)):
+        logging.warning(
+            'Ignoring malformed {} for user {!r}'.format(filename, username))
+        return empty
+    return payload
+
+
+def _write_json(base_dir, username, filename, payload_key, payload):
+    user_dir = get_user_data_dir(base_dir, username)
+    try:
+        os.makedirs(user_dir, mode=0o700, exist_ok=True)
+    except PermissionError:
+        raise ValueError(
+            'Cannot create data directory for user {!r}: permission denied. '
+            'Check ownership of {!r}'.format(username, base_dir)
+        )
+
+    body = json.dumps(
+        {'version': SCHEMA_VERSION, payload_key: payload}, indent=2
+    ).encode()
+
+    path = os.path.join(user_dir, filename)
+    fd, tmp_path = tempfile.mkstemp(dir=user_dir)
+    closed = False
+    try:
+        os.write(fd, body)
+        os.fchmod(fd, 0o600)
+        os.close(fd)
+        closed = True
+        os.rename(tmp_path, path)
+    except Exception:
+        os.unlink(tmp_path)
+        raise
+    finally:
+        if not closed:
+            try:
+                os.close(fd)
+            except OSError:
+                pass
+
+
+def read_hosts(base_dir, username):
+    return _read_json(base_dir, username, HOSTS_FILENAME, 'hosts', [])
+
+
+def write_hosts(base_dir, username, hosts):
+    validated = validate_hosts(hosts)
+    _write_json(base_dir, username, HOSTS_FILENAME, 'hosts', validated)
+    return validated
+
+
+def read_settings(base_dir, username):
+    return _read_json(base_dir, username, SETTINGS_FILENAME, 'settings', {})
+
+
+def write_settings(base_dir, username, settings):
+    validated = validate_settings(settings)
+    _write_json(
+        base_dir, username, SETTINGS_FILENAME, 'settings', validated)
+    return validated

--- a/webssh/user_data.py
+++ b/webssh/user_data.py
@@ -12,6 +12,7 @@ from webssh.utils import is_valid_encoding
 SCHEMA_VERSION = 1
 MAX_HOSTS = 200
 MAX_FIELD_LENGTH = 512
+MAX_CORRUPT_COPIES = 20
 
 HOSTS_FILENAME = 'hosts.json'
 SETTINGS_FILENAME = 'settings.json'
@@ -122,29 +123,62 @@ def validate_settings(settings):
     return result
 
 
+def quarantine_file(path):
+    """Move an unreadable data file aside so a later write cannot destroy it.
+
+    Returns the path the file was moved to, or None if it could not be
+    moved. An existing .corrupt file is never overwritten; a numeric
+    suffix is added instead.
+    """
+    target = path + '.corrupt'
+    suffix = 0
+    while os.path.exists(target):
+        suffix += 1
+        if suffix > MAX_CORRUPT_COPIES:
+            logging.error(
+                'Not quarantining {!r}: too many .corrupt files '
+                'already present'.format(path)
+            )
+            return None
+        target = '{}.corrupt.{}'.format(path, suffix)
+    try:
+        os.rename(path, target)
+    except OSError as exc:
+        logging.error(
+            'Could not quarantine unreadable file {!r}: {}'.format(path, exc))
+        return None
+    return target
+
+
 def _read_json(base_dir, username, filename, payload_key, empty):
     user_dir = get_user_data_dir(base_dir, username)
     path = os.path.join(user_dir, filename)
     if not os.path.isfile(path):
         return empty
+
+    def give_up(reason):
+        # The caller cannot distinguish "no data" from "unreadable data", and
+        # a later save would overwrite the file with the empty payload. Move
+        # the original aside so it stays recoverable.
+        target = quarantine_file(path)
+        logging.error(
+            'Unreadable {} for user {!r}: {}{}'.format(
+                filename, username, reason,
+                '; moved to {!r}'.format(target) if target else ''
+            )
+        )
+        return empty
+
     try:
         with open(path, 'r') as f:
             data = json.load(f)
     except (ValueError, OSError) as exc:
-        logging.warning(
-            'Ignoring unreadable {} for user {!r}: {}'.format(
-                filename, username, exc)
-        )
-        return empty
+        return give_up(exc)
     if not isinstance(data, dict):
-        logging.warning(
-            'Ignoring malformed {} for user {!r}'.format(filename, username))
-        return empty
+        return give_up('payload is not a mapping')
     payload = data.get(payload_key, empty)
     if not isinstance(payload, type(empty)):
-        logging.warning(
-            'Ignoring malformed {} for user {!r}'.format(filename, username))
-        return empty
+        return give_up('{!r} has the wrong type'.format(payload_key))
     return payload
 
 


### PR DESCRIPTION
Adds an opt-in feature letting each signed-in user maintain a private SSH host list and a set of preferences, stored server-side so they roam across browsers and machines — plus a JavaScript test suite for the client code it introduces.

Design: `docs/superpowers/specs/2026-07-27-user-editable-hosts-design.md`
Plan: `docs/superpowers/plans/2026-07-27-user-editable-hosts.md`

## The feature

- **`webssh/user_data.py`** — per-user JSON under `<userdatadir>/<username>/`, mirroring the existing `user_keys.py` layout and its atomic-write and path-traversal guards. `userdatadir` defaults to `userkeydir`, so deployments already using per-user keys need no new configuration.
- **`/api/hosts` and `/api/settings`** — JSON read/write, XSRF-protected, gated on the `user_hosts` flag.
- **Connect-time merge** — user hosts are merged with the administrator allowlist in `IndexHandler`.
- **In-app settings tab** — settings open as a tab inside the existing tab bar rather than a page, so opening them never tears down a live terminal session.
- **Roaming preferences** — last-used form values and terminal appearance move from `localStorage`/URL-params to server-side storage, with a one-time migration of existing per-host default commands.

## Security notes

`hosts:` in `config.yaml` is a security allowlist. Enabling `user_hosts` deliberately lets users connect outside it, so the feature is **opt-in and defaults to off** — an existing deployment that does not set it behaves exactly as before. This is stated plainly in both the README and `config.yaml.example`, ahead of the copy-pasteable example.

Two invariants are enforced and tested:

- An administrator entry always wins a `hostname:port` collision — the colliding user entry is dropped from the merged list entirely, so a user cannot override a pinned production host key.
- User host key pins are isolated per request. Paramiko's `HostKeys` was previously a process-global object shared by every request; once user-supplied keys could reach it, one user's pin persisted process-wide and was visible to all others. Under `policy: reject` that widened the connect gate for everyone, and since `HostKeys.add` replaces a matched entry, it also allowed overwriting an administrator's `known_hosts` pin. Now copied per request when the feature is on, with the disabled path left byte-identical.

Credentials, TOTP codes, and key passphrases are never stored server-side; `validate_settings` whitelists keys, and the client is separately constrained to only send known roaming fields.

## JavaScript test coverage

The feature shipped roughly a thousand lines of client JavaScript into a repository with no JS test harness. Review of the client-side work found one Critical and eight Important defects, against roughly one per server-side task — so the coverage gap was measurable, not theoretical.

The pure decision logic now lives in `webssh/static/js/user-hosts.js` (host payload construction, port validation, settings merging, preference precedence, legacy command migration) with DOM reading left behind in `main.js`. That purity means the suite needs **no dependencies at all** — `node --test`, no jsdom, no npm packages, no lockfile in an otherwise-Python repository.

48 tests, each tracing to a defect that review or browser testing actually found. A `js` job runs them on Node 20, 22 and 24, and `docker` depends on it, so a JavaScript failure blocks release exactly as a Python failure does.

Two things the suite deliberately does *not* cover, stated so nobody reads "JS tests exist" as "the client is covered": tab lifecycle and the hostname input/select upgrade, and asynchronous save sequencing — including the guard that prevents a save from clearing hosts before the list has loaded. Those remain verified by review and by scripted browser passes.

## Testing

234 Python tests (up from 152 on `main`) and 48 JavaScript tests. The client was additionally driven in a real browser via Playwright across several passes, covering the settings tab, host editing, live dropdown refresh, roaming across a simulated second machine, and an XSS probe with a host named `<img src=x onerror=...>`.

Deferred follow-ups are recorded in `docs/superpowers/specs/2026-07-27-user-editable-hosts-followups.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
